### PR TITLE
Bug fixes from develop: Tall AI key check, topic-model tuning, multi-word merge, and 29 more

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@ inst/bbc$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^AGENTS.md
+^\.positai$
+^\.claude$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,5 @@ inst/bbc$
 ^AGENTS.md
 ^\.positai$
 ^\.claude$
+^openalex_
+^tasks(/|$)

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ src/tall.so
 CRAN-SUBMISSION
 AGENTS.md
 /.quarto/
+/openalex_*
+/tasks/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Description: An R 'shiny' app designed for diverse text analysis tasks, offering
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 URL: https://github.com/massimoaria/tall,
      https://massimoaria.github.io/tall-app/
 BugReports: https://github.com/massimoaria/tall/issues
@@ -94,3 +93,4 @@ Suggests:
 Config/testthat/edition: 3
 LazyData: true
 LinkingTo: Rcpp
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,35 @@
 # tall (development version)
 
+* Bug fix (KWIC > In-Document Plot > View): clicking the "View" button of a
+  document whose annotation contains an unresolved lemma (`NA`) aborted the
+  document modal with "missing value where TRUE/FALSE needed". Comparing an NA
+  term with the query yields NA rather than FALSE, and `buildDocumentHTML()`
+  branches on that value once per token. The match flag now treats an
+  unresolvable term as a non-match, and the token branch uses `isTRUE()` so the
+  helper stays total for any caller. Documents without NA terms render exactly
+  as before, byte for byte. Note the table lists every selected document,
+  including those whose frequency is NA, so the button was reachable on any
+  corpus with an unresolved lemma (e.g. a single `upos = "X"` token).
+
+* Bug fix (Overview > Morphological Features): `parseMorphFeatures()` built its
+  match mask from the vector returned by `regmatches()`, which is *compacted* to
+  the matching elements only. Being all-TRUE and shorter than the input, the mask
+  was recycled when used to index the full-length result, so the extracted values
+  were sprayed cyclically across every token instead of landing on the tokens
+  that actually carry the feature. As a consequence no row was dropped as NA:
+  the feature distribution bar chart reported counts inflated to the whole
+  corpus token count (percentages were approximately right, absolute counts were
+  not) and the feature x part-of-speech cross-tabulation was meaningless. The
+  mask is now derived from `regexpr()` over the full column, so non-matching
+  tokens correctly stay NA.
+
+* Bug fix (Reinert clustering): in the greedy reallocation step (`switch_docs`),
+  the document to move was looked up in the original CA ordering instead of the
+  current group order. After the first switch this could move the wrong segment
+  and made the clustering depend on the arbitrary sign of the SVD first axis
+  (i.e., results could differ across platforms/LAPACK builds on the same data).
+  Partitions computed with previous versions may change slightly.
+
 # tall 1.0.0
 * Changelog:                                      
                                          

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # tall (development version)
 
+* Bug fix (Settings > Tall AI): the chosen Gemini model and output size were
+  never remembered. They were written to `~/.tall_gemini_model.txt` and read
+  back from `~/tall/.tall_gemini_model.txt` — a different file — so every
+  session started on `2.5-flash` / `medium` whatever the user had picked. Two
+  further defects in the same path: the model observer saved
+  `input$gemini_output_model`, an input that does not exist (the control is
+  `gemini_output_size`), so choosing a model also dropped the output size; and
+  `loadGeminiModel()` tested `length(model == 1)` — the length of a *logical*
+  vector, hence always at least 1 — so it appended a third element to an
+  already complete pair. There is now a single `geminiModelFile()` used by both
+  the writer and the reader.
+
 * Bug fix (Settings > Working Folder): "Clean Model Cache" removed the whole
   `~/tall` folder, not the model cache. It took the Gemini API key
   (`.tall_gemini_key.txt`), the graph-export settings

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,42 @@
 # tall (development version)
 
+* Bug fix (Words > Word Embeddings > Similarity): the community-detection step
+  built its lookup table with `data.frame(as.list(membership(cluster)))`, which
+  runs `make.names()` over the vertex names. Every term that is not a syntactic
+  R name therefore lost the join that follows and was **silently dropped from
+  the network** — no warning, no gap, just a smaller plot. This is not an exotic
+  case: it covers hyphens and apostrophes (`e-mail`), a leading digit (`3d`,
+  `30`), everything TALL's own entity tagging produces (hashtags, mentions,
+  emoji, URLs) and R's reserved words, so ordinary English terms such as `next`,
+  `break`, `in` and `for` disappeared too. On the US-airlines corpus 6,789 of
+  the 16,537 selected lemmas were affected, including 2 of the 100 words the
+  view is asked to plot. The table is now built directly from the membership
+  names and every node reaches the canvas.
+
+* Bug fix (Words > Word Embeddings > Similarity): when no pair of words reached
+  the hard-coded 0.5 similarity cutoff the empty edge list reached
+  `graph_from_data_frame()`, and the view died with `Can't rename columns that
+  don't exist. Column 'V1' doesn't exist.` — a `dplyr` message with nothing to
+  connect it to the cutoff. The network now renders a single label saying that
+  no pair reaches the threshold.
+
+* Bug fix (Words > Word Embeddings > Similarity > UMAP): with a single word to
+  place, the label de-overlap routine ran `1:(nrow(df) - 1)`, which counts
+  **down** to 0, so it compared row 0 with row 1 and stopped on `missing value
+  where TRUE/FALSE needed`. Nothing can overlap with itself, and the loop is now
+  skipped in that case.
+
+* Bug fix (Words > Word Embeddings): `word2vec` keeps a `</s>` sentence-boundary
+  sentinel in its model matrix. It is not a word of the corpus and its vector is
+  essentially untrained, but every consumer read the matrix with `as.matrix()`
+  and included it: on Frankenstein its norm is 4.47 against a mean absolute
+  component of 0.81 for real terms, which made it the Min or the Max in 10 of
+  the 20 dimensions of the Training tab, shifted Kurtosis by up to 183 and
+  dropped the variance explained by PC1 from 0.591 to 0.501 — in the very chart
+  that tab exists to show. It could also surface as a neighbour in the
+  similarity network and as a row of the exported matrix. A new `w2vMatrix()`
+  accessor drops it, and all consumers go through it.
+
 * Bug fix (Documents > Supervised Classification > Download Results): the
   export read `test_data$target`, but the model frame names that column
   `.target_class`, and "target" is not a prefix of it, so `$` could not reach it

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,35 @@
 # tall (development version)
 
+* Bug fix (Documents > Topic Modeling > Find optimal K): **the page tuned LDA
+  with a different algorithm from the one that then estimates the model.**
+  `tmTuningAsync()` fitted `LDA(dtm, k, method = "VEM")` while `tmEstimate()`
+  fits `LDA(dtm, K, method = "Gibbs", control = list(iter = 500, seed = seed))`,
+  so the number of topics a user was shown had been chosen for a model class
+  they never fitted — two different inference algorithms, one picking K for the
+  other. CTM was never affected (the same `CTM()` runs on both pages) and STM
+  tunes through `stm::searchK`, which fits stm models. The tuning now uses
+  `method = "Gibbs"` with `tmEstimate()`'s own control list, iterations
+  included, so the model that is scored and the model that is estimated are the
+  same fit. ⚠ **The recommended K will change on existing corpora** — that is
+  the point of the fix, not a side effect. `evaluate_single_k()` is kept in
+  step for the same reason, although nothing calls it.
+
+* Performance (Documents > Topic Modeling > Find optimal K): the grid is fitted
+  **across cores** instead of one model after another, and each worker now also
+  computes its own model's `logLik` and `perplexity` — which were half the wall
+  clock when they were left to the calling process — returning only the numbers
+  the metrics need (`exp(beta)` and `len %*% gamma`, a vector of length K)
+  rather than the fitted model. Measured on a 22,053-unit corpus over the
+  default grid K = 2..20: **36.7s to 5.8s, 6.4x**. The metrics come back
+  bit-identical, which is what makes the change safe to describe as
+  performance: every fit is independent and carries the same seed, so the
+  result cannot depend on the order the workers finish in. If a cluster cannot
+  be created the grid is fitted serially rather than the page failing, and on a
+  grid small enough to finish instantly the cluster's own start-up dominates
+  (0.2s to 0.4s on a 593-unit corpus over K = 2..6). `tmTuningAsync()` no
+  longer returns the fitted `models`: nothing read them, and carrying them back
+  through the socket was the single largest cost.
+
 * Bug fix (Documents > Topic Modeling > Find optimal K): on the "Multi-Metric
   Comparison" chart, two of the four curves were drawn upside down against the
   chart's own y axis, which reads "Normalized Score (0 = worst, 1 = best)".

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # tall (development version)
 
+* Bug fix (Documents > Topic Modeling > Model Estimation): the document labels
+  of `theta` were wrong under every estimation method, and the two branches were
+  wrong in two different ways. `tmEstimate()` (LDA and CTM) labelled each row
+  with `unique(x$doc_id)[as.numeric(row.names(tmResult$topics))]`, but those row
+  names are `topic_level_id` values — the ANALYSIS UNIT, a sentence whenever
+  `group` includes `sentence_id` — not positions in the list of documents, so
+  indexing the document vector with a unit id returned `NA` for every unit past
+  the number of documents and misattributed the few that did resolve. Measured
+  on `mobydick` at sentence units (836 units, 10 documents): 826 of 836 labels
+  were `NA`, and of the 10 that were not, only ONE was right. `stmEstimate()`
+  took the first `nrow(theta)` entries of the unit list instead, which slides the
+  labels as soon as the unit ids are not the leading ones — they are neither
+  contiguous (`LemmaSelection()` drops units, so the ids skip: 3, 4, 5, 7, …) nor
+  guaranteed to start at 1 (empty units are dropped before the fit). Measured on
+  `frankenstein` at sentence units, 153 of 593 rows were attributed to the wrong
+  document — silently, since no label came back `NA`. The visible symptom of both
+  is "Topic by Docs Plot", whose y axis became a column of `NA` under LDA/CTM and
+  a plausible but wrong set of documents under STM. It went unnoticed because the
+  "Topics" selector defaults to Docs, where unit ids and document positions
+  coincide. Each row is now matched back to its own unit.
+
 * Bug fix (Import > Wikipedia pages): nothing on this path was URL-encoded, and
   each of the three consequences was reachable from the ordinary use of the
   menu. A page whose title contains a non-ASCII character — `Zürich`, `Café`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,46 @@
 # tall (development version)
 
+* Bug fix (Settings > Tall AI): **a valid Gemini API key was reported as
+  refused, and a new user could not run TALL AI at all.** Key validation sent a
+  real `generateContent` request to a hard-coded `gemini-2.5-flash`
+  (`settings.R`), and Google has stopped serving the 2.5 family to newly created
+  API keys — so the probe returned `404 ... no longer available to new users`
+  and the app said "API key seems be not valid", whatever model was selected.
+  The first-run default was `2.5-flash` too (`loadGeminiModel()`), so even a key
+  that got through had nothing it could call. Same defect as bibliometrix #637,
+  found by carrying that fix across.
+  - **Validation is now model-agnostic**: the new `.geminiAvailableModels()`
+    asks for the model CATALOGUE (`GET /v1beta/models`) instead of invoking a
+    model, so no future retirement can break it. `geminiValidateKey()` returns
+    the key's verdict and the chosen model's availability as two separate
+    answers.
+  - **The selected model is checked**: if it is not in the catalogue for that
+    key, Settings says so — instead of letting the user discover it as an HTTP
+    404 at the first analysis.
+  - **Errors are told apart.** `grepl("HTTP\\s*[1-5][0-9]{2}")` collapsed every
+    status from 100 to 599 into one "invalid key" message; 400/401 now mention
+    the key, 403 a permission, 404 the model, and a transport failure says it is
+    a connection problem. `req_error()` also lets Google's own message through:
+    `resp_body_string()` was being handed a hand-built list, so the real reason
+    was never shown.
+  - **A connection failure no longer crashes the check.** The connection-level
+    branch in `gemini_ai()` was commented out, leaving `status_code = NA`, so
+    `if (resp$status_code == 400)` evaluated `if (NA)` and the user saw
+    *"missing value where TRUE/FALSE needed"* instead of "there is no network".
+  - **Defaults moved off the retired family** to `gemini-3.5-flash-lite`
+    (transport default, first-run default and model selector). A stored
+    `2.5-flash` — which was the old default rather than anyone's choice — is
+    carried forward; a deliberately chosen `2.5-flash-lite` is kept. The 2.5
+    pair stays selectable under a **Legacy** group, since keys created before
+    the cut-off still reach it.
+  - **Preview ids removed from the selector** (`3-flash-preview`,
+    `3.1-pro-preview`): they carry their own expiry date. `gemini-flash-latest`
+    added.
+  - `setGeminiAPI()` removed: unreachable (no callers anywhere in the package)
+    and a duplicate of the same faulty probe. `abstractive_summary()`, also
+    unreachable and superseded by the inline block in `documents.R`, had its own
+    stale `2.0-flash` default corrected and is now marked as superseded.
+
 * Bug fix (Documents > Topic Modeling > Find optimal K): **the page tuned LDA
   with a different algorithm from the one that then estimates the model.**
   `tmTuningAsync()` fitted `LDA(dtm, k, method = "VEM")` while `tmEstimate()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # tall (development version)
 
+* Bug fix (Documents > Summarization > Extractive): `textrankDocument()` joined
+  the ranked sentences back to the corpus by the TEXT of the sentence
+  (`by = c("sentence")`), not by its id. Any document that repeats a sentence
+  therefore produced a many-to-many join: a text said k times contributed k^2
+  rows instead of k, and every copy inherited every paragraph that carries that
+  text. Because `nrow(s)` is what `abstractingDocument()` takes its slider
+  percentages of, the summary length moved with the duplication as well. On the
+  `usairlines` collection a four-sentence tweet whose text repeats three times
+  was rendered as ten sentences; `mobydick_ita` repeats 819 of its 12,356. The
+  join now uses the sentence id, as the neighbouring `highlightSentences()`
+  already did.
+
+* Bug fix (Documents > Summarization > Extractive): the view failed on a grouped
+  corpus, on its own default setting. "Summarize: Documents" lists original
+  document ids (`ids()` un-groups before listing), while the summary ran on
+  `values$dfTag`, still keyed by group — so the selected id was absent from the
+  data and the view stopped inside `textrank_sentences()` with
+  `nrow(data) > 1 is not TRUE`. Grouping under FEATURES and pressing Run was
+  enough to reach it. The frame is now un-grouped whenever the unit is not
+  "Groups".
+
 * Bug fix (Settings > Tall AI): the chosen Gemini model and output size were
   never remembered. They were written to `~/.tall_gemini_model.txt` and read
   back from `~/tall/.tall_gemini_model.txt` — a different file — so every

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # tall (development version)
 
+* Bug fix (Import > Wikipedia pages): nothing on this path was URL-encoded, and
+  each of the three consequences was reachable from the ordinary use of the
+  menu. A page whose title contains a non-ASCII character — `Zürich`, `Café`,
+  `Pokémon` — made the API answer *400 Bad Request*, and because one failing
+  page stops the extraction loop, a single such hit among the results left the
+  import with nothing. A search phrase containing `&` had everything after it
+  read as a new API parameter, so the query silently ran on the truncated
+  phrase. And a phrase containing an en dash was turned into one containing a
+  literal space by `wikiSearch()`'s own `gsub("–", " ", …)`, which makes the URL
+  illegal and aborts the import with a connection error rather than the
+  "No results found!" message. Both the search phrase and the page title are now
+  passed through `URLencode(reserved = TRUE)`.
+
 * Bug fix (Documents > Summarization > Extractive): `textrankDocument()` joined
   the ranked sentences back to the corpus by the TEXT of the sentence
   (`by = c("sentence")`), not by its id. Any document that repeats a sentence

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,43 @@
 # tall (development version)
 
+* Bug fix (Features > Feature Roles): applying a keyness role to a **binary
+  variable that contains missing values** aborted with "the condition has length
+  > 1", after `keyness_group` had already been written to the corpus — so the
+  roles were applied but the confirmation never appeared. The per-group document
+  count did not drop the `NA` group, so `doc_groups$n[doc_groups$keyness_group ==
+  1]` returned two elements, the success message became a length-2 vector and the
+  final `if (success_message == "")` threw. The count now filters the missing
+  group and guards an empty one, as the multi-category branch already did.
+
+* Bug fix (Features > Feature Roles): the time and label roles were assigned
+  **before** the keyness groups were validated, and the validation aborts with
+  `return()`. Rejecting an Apply for missing or overlapping group assignments
+  therefore left a half-applied state (time and label silently assigned, keyness
+  not). The group checks now run first, so a rejected Apply changes nothing.
+
+* Bug fix (Features > Feature Roles): the category list of the keyness variable
+  was read from the raw token-level column, while the Group 1 / Group 2 pickers
+  offer the categories of the *selected* documents. With a filter active the two
+  could disagree — a variable reduced to two categories by the filter still took
+  the "more than 2 categories" branch and demanded an assignment the pickers
+  could not offer. Both now use the same document-level, filtered set.
+
+* Bug fix (Features > Feature Roles > Preview): the "Documents per period" table
+  of a date variable was ordered by ascending document count (`sort()` on a
+  `table()` sorts the counts), not chronologically.
+
+* Bug fix (Features > Feature Roles): aggregating a date-time variable by **Day**
+  did not aggregate at all — `as.character()` on a `POSIXct` keeps the clock
+  time, so every distinct second became its own period. It now formats to the
+  calendar day.
+
+* Bug fix (Features): `noGroupLabels()` did not reserve `time_agg`, the column
+  the time role derives, although it reserves `keyness_group`. After assigning a
+  date time role, tall's own aggregation key appeared as a user feature in
+  Filters, Groups (where grouping by it would re-key the documents), the topic
+  model covariates and Feature Roles itself, and its presence alone could unlock
+  the FEATURES menu.
+
 * Bug fix (Pre-processing > Multi-Word Creation / Multi-Word by a List): the
   words absorbed into a multi-word were left in the corpus as separate tokens.
   Merging "natural philosophy" produced the multi-word AND kept `philosophy` as

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # tall (development version)
 
+* Bug fix (Pre-processing > Multi-Word Creation / Multi-Word by a List): the
+  words absorbed into a multi-word were left in the corpus as separate tokens.
+  Merging "natural philosophy" produced the multi-word AND kept `philosophy` as
+  its own selected NOUN, so every downstream count (vocabulary, keyness,
+  networks, topic models) saw the constituents twice. Two chained causes, both
+  fixed: (1) the vectorised rewrite of the tagging step nested what used to be
+  two sequential `ifelse()` calls, and on an absorbed position `multiword` is
+  `NA`, so the outer test evaluated to `NA` and the `NGRAM_MERGED` branch became
+  unreachable — the tags now come from an explicit "was absorbed" flag, which
+  also leaves a genuinely `NA` term alone; (2) `applyRake()` kept a
+  `NGRAM_MERGED` row only when its own `multiword` was among the selected
+  keywords, but that value is `NA` on those rows by construction, so they were
+  always dropped and the join restored the original tags. The tagging step now
+  reports which keyword absorbed each position (`mw_owner`) and `applyRake()`
+  matches the constituents through it, so a partial selection keeps exactly the
+  constituents of the keywords you ticked. Constituents are now tagged
+  `NGRAM_MERGED` with `POSSelected = FALSE` — their text stays in the sentence,
+  they are only excluded from the analyses — and `rakeReset()` ("Back") restores
+  the previous selection from `POSSelected_original_nomultiwords`.
+
 * Bug fix (KWIC > In-Document Plot > View): clicking the "View" button of a
   document whose annotation contains an unresolved lemma (`NA`) aborted the
   document modal with "missing value where TRUE/FALSE needed". Comparing an NA

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,34 @@
 # tall (development version)
 
+* Bug fix (Documents > Topic Modeling > Find optimal K): on the "Multi-Metric
+  Comparison" chart, two of the four curves were drawn upside down against the
+  chart's own y axis, which reads "Normalized Score (0 = worst, 1 = best)".
+  `tmMultiMetricPlot()` carried a per-metric flag named `decreasing` and its
+  normalisation branch treated that flag as "higher is better", while the flags
+  themselves had been assigned as though it meant "lower is better". Under LDA
+  and CTM this put the best K of **CaoJuan2009** and of **Perplexity** — both
+  minimised — at the BOTTOM of a chart that says the bottom is worst; under STM
+  it did the same to **Semantic Coherence** and to the **Lower Bound**, both of
+  which are maximised. A reader comparing curves was therefore reading two of
+  them backwards. The flag is now `higher_better`, set from what each metric
+  actually wants, and 1 is the good end for every curve on both branches
+  (verified by execution: all eight metrics now plot their optimum at y = 1).
+
+  The recommended K values do not change, and could not have: `find_elbow()`
+  ignores its `decreasing` argument. Negating the metric reflects the whole
+  configuration about the x axis, and the distance from a point to a line is
+  invariant under reflection, so `which.max(distances)` returns the same index
+  either way — confirmed on 2000 random metric shapes, identical 2000/2000, and
+  on the patch itself, where every K came back unchanged. The argument is kept,
+  because it documents which way a metric runs, but it is now labelled as
+  having no effect so that nobody "fixes" the flags expecting a different K.
+
+* Documentation fix (Documents > Topic Modeling > Find optimal K): the
+  "K Recommendation" tab described Deveaud 2014 as "Jensen-Shannon divergence
+  between topic pairs. Lower = more separated topics." A divergence is larger
+  when distributions are further apart, which is why Deveaud 2014 is maximised;
+  the sentence said the opposite of both the statistic and the code beside it.
+
 * Bug fix (Documents > Topic Modeling > Model Estimation): the document labels
   of `theta` were wrong under every estimation method, and the two branches were
   wrong in two different ways. `tmEstimate()` (LDA and CTM) labelled each row

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # tall (development version)
 
+* Bug fix (Settings > Working Folder): "Clean Model Cache" removed the whole
+  `~/tall` folder, not the model cache. It took the Gemini API key
+  (`.tall_gemini_key.txt`), the graph-export settings
+  (`.tall_graph_settings.txt`), the working-folder pointer (`tallWD.tall`) and
+  any `.tall` project the user had saved in that folder — none of which can be
+  downloaded again — under a button that names only the models. It now removes
+  `~/tall/language_models` and says so, and the alert states what has been kept.
+
+* Bug fix (start-up): an empty or blank `~/tall/tallWD.tall` aborted the session
+  with `argument is of length zero`. `readLines()` of an empty file returns
+  `character(0)`, and `file.exists(character(0))` returns `logical(0)`, which
+  `if` cannot evaluate — and `wdFolder()` is called from `resetValues()` before
+  there is any UI to report the error in. A blank pointer file is now treated as
+  no working folder, and removed.
+
 * Bug fix (Words > Word Embeddings > Similarity): the community-detection step
   built its lookup table with `data.frame(as.list(membership(cluster)))`, which
   runs `make.names()` over the vertex names. Every term that is not a syntactic

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,46 @@
 # tall (development version)
 
+* Bug fix (Documents > Supervised Classification > Download Results): the
+  export read `test_data$target`, but the model frame names that column
+  `.target_class`, and "target" is not a prefix of it, so `$` could not reach it
+  either. Two outcomes, both reproduced on a real corpus: normally `$target`
+  returned `NULL` and `tibble()` raised a recycling error **inside the download
+  handler**, so the whole .xlsx failed and none of its five sheets was written;
+  and on a corpus that happens to contain a term whose sanitised column name is
+  exactly `target` — the US-airlines tweets do — `$` resolved to that TF-IDF
+  column instead, and the file was written with numbers in the `Actual` column
+  and `Correct` false on every row. The lookup is now `[[".target_class"]]`,
+  which also cannot fall back to partial matching.
+
+* Bug fix (Documents > Supervised Classification): `ranger`'s
+  `prediction.error` was displayed as "OOB Prediction Error (%)" in the training
+  summary, the success dialog and the exported workbook. For a `probability =
+  TRUE` forest that field is the out-of-bag **Brier score**, not a
+  misclassification rate — 0.21 on the reference run, which invited reading it
+  as "21% of documents misclassified". It is now labelled and formatted as a
+  Brier score.
+
+* Bug fix (Documents > Supervised Classification): the training-set accuracy was
+  computed from **in-sample** predictions, so it is optimistically biased by
+  construction (0.92 against 0.75 on the held-out set in the reference run) and
+  read like a second, reassuring validation score. It is now labelled
+  "Train Set Accuracy (in-sample)".
+
+* Bug fix (Documents > Supervised Classification): training word embeddings from
+  this menu overwrote the shared `values$w2v_model` used by Words > Embeddings
+  with a differently parameterised, stopword-free model, while leaving
+  `values$w2v_stats` and `values$df_EmbeddingDims` describing the previous one —
+  so the embedding views silently changed under the user. The model trained here
+  is now kept inside the classification menu and the shared one is only read.
+
+* Bug fix (Documents > Supervised Classification): a failed training run left
+  the results panel showing the previous model, because the error handler did
+  not clear the `trained` flag.
+
+* Bug fix (Documents > Supervised Classification): the prerequisite check
+  aborted with "missing value where TRUE/FALSE needed" when `docSelected`
+  contained any `NA`, since `sum()` then returns `NA` and `if (NA)` is an error.
+
 * Bug fix (Features > Feature Roles): applying a keyness role to a **binary
   variable that contains missing values** aborted with "the condition has length
   > 1", after `keyness_group` had already been written to the corpus — so the

--- a/R/reinert.R
+++ b/R/reinert.R
@@ -336,7 +336,13 @@ switch_docs <- function(m, indices, max_index, max_chisq) {
 
     if (current_max > max_chisq) {
       switched <- TRUE
-      to_switch <- indices[which.max(chisq_values)]
+      # chisq_values positions refer to the CURRENT rows of tab1/tab2, i.e. to
+      # c(group1, group2): after the first switch this differs from `indices`,
+      # so the lookup must use the current group order. Using `indices` here
+      # switched the wrong document and made the result depend on the
+      # arbitrary sign of the SVD in order_docs().
+      current_order <- c(group1, group2)
+      to_switch <- current_order[which.max(chisq_values)]
       if (to_switch %in% group1) {
         group1 <- group1[group1 != to_switch]
         group2 <- c(group2, to_switch)

--- a/R/txt_recode_fast.R
+++ b/R/txt_recode_fast.R
@@ -152,7 +152,10 @@ NULL
 #' @param stats Data frame with multiword statistics (keyword, ngram columns)
 #' @param term Type of term to process: "lemma" or "token"
 #'
-#' @return Data frame with columns: doc_id, term_id, multiword, upos_multiword, ngram
+#' @return Data frame with columns: doc_id, term_id, multiword, upos_multiword,
+#'   ngram, mw_owner (the keyword that absorbed a NGRAM_MERGED position, NA
+#'   elsewhere — \code{applyRake()} needs it to keep the constituents of the
+#'   selected keywords only)
 #'
 #' @details
 #' This function replaces the original switch block with an optimized version
@@ -187,11 +190,28 @@ process_multiwords_fast <- function(x2, stats, term = c("lemma", "token")) {
     sep = " "
   )
 
-  # Operazioni vettorizzate (molto più veloci di mutate multiple)
+  # Posizioni assorbite da un multiword (il kernel le mette a NA). Un termine
+  # gia' NA in partenza non e' un costituente: la condizione guarda term_col.
+  merged_away <- is.na(multiword) & !is.na(term_col)
+
+  # keyword che ha assorbito ciascun costituente (ultima testa a monte)
+  owner <- multiword
+  owner[merged_away] <- NA_character_
+  last_head <- cummax(ifelse(is.na(owner), 0L, seq_along(owner)))
+  mw_owner <- ifelse(
+    merged_away & last_head > 0L,
+    owner[pmax(last_head, 1L)],
+    NA_character_
+  )
+
+  # Operazioni vettorizzate (più veloci di mutate multiple). L'ordine dei due
+  # ifelse è vincolante: con il test `term_col == multiword` all'esterno il
+  # ramo NGRAM_MERGED è irraggiungibile, perché su una posizione assorbita
+  # multiword è NA e ifelse(NA, ...) restituisce NA.
   upos_multiword <- ifelse(
-    term_col == multiword,
-    x2$upos,
-    ifelse(is.na(multiword), "NGRAM_MERGED", "MULTIWORD")
+    merged_away,
+    "NGRAM_MERGED",
+    ifelse(term_col == multiword, x2$upos, "MULTIWORD")
   )
 
   # Lookup diretto invece di join
@@ -204,6 +224,7 @@ process_multiwords_fast <- function(x2, stats, term = c("lemma", "token")) {
     multiword = multiword,
     upos_multiword = upos_multiword,
     ngram = unname(ngram_values),
+    mw_owner = mw_owner,
     stringsAsFactors = FALSE
   )
 }

--- a/inst/tall/collocation.R
+++ b/inst/tall/collocation.R
@@ -742,9 +742,12 @@ collocationServer <- function(input, output, session, values, statsValues) {
     }
 
     # Mark matches
+    # !is.na() first: comparing an NA term with the query yields NA, not FALSE,
+    # and buildDocumentHTML() branches on this value per token. A token whose
+    # lemma the annotator could not resolve is simply not a match.
     doc_df <- doc_df %>%
       mutate(
-        is_match = search_col == query_lower
+        is_match = !is.na(search_col) & search_col == query_lower
       )
 
     # Build HTML with highlighted terms
@@ -1217,7 +1220,10 @@ buildDocumentHTML <- function(doc_df, term_col) {
           token <- tokens[j]
           is_match <- matches[j]
 
-          if (is_match) {
+          # isTRUE(): `if (NA)` is an error, so an NA here would abort the whole
+          # modal. The caller already resolves NA terms to FALSE; this keeps the
+          # function total for any other caller.
+          if (isTRUE(is_match)) {
             # Highlight matched token
             paste0(
               '<span style="background-color: #ffeb3b; font-weight: bold; padding: 2px 4px; border-radius: 3px;">',

--- a/inst/tall/doc_classification.R
+++ b/inst/tall/doc_classification.R
@@ -457,6 +457,9 @@ docClassificationServer <- function(input, output, session, values) {
     term_mapping = NULL, # Mapping between original terms and sanitized names
     eval_train = NULL,
     eval_test = NULL,
+    ## embeddings trained by THIS menu when the user has none: kept here so the
+    ## shared values$w2v_model of Words > Embeddings is never overwritten
+    w2v_model = NULL,
     trained = FALSE
   )
 
@@ -603,26 +606,34 @@ docClassificationServer <- function(input, output, session, values) {
           )
         } else {
           # Word2Vec approach
-          # Check if model exists, if not train it
-          if (is.null(values$w2v_model)) {
-            showNotification(
-              "Word2Vec model not found. Training with default parameters...",
-              type = "warning",
-              duration = 5
-            )
-
-            values$w2v_model <- trainWord2Vec(
-              dfTag = values$dfTag,
-              term = values$generalTerm,
-              dim = 100,
-              iter = 20
-            )
+          # Use the embeddings trained in Words > Embeddings when they exist;
+          # otherwise train one FOR THIS MENU ONLY. Writing into
+          # values$w2v_model would replace the shared model with a
+          # differently parameterised, stopword-free one and leave
+          # values$w2v_stats / values$df_EmbeddingDims describing the old one,
+          # so every embeddings view would silently change under the user.
+          w2v_model <- values$w2v_model
+          if (is.null(w2v_model)) {
+            if (is.null(rf_results$w2v_model)) {
+              showNotification(
+                "Word2Vec model not found. Training with default parameters (for this menu only)...",
+                type = "warning",
+                duration = 5
+              )
+              rf_results$w2v_model <- trainWord2Vec(
+                dfTag = values$dfTag,
+                term = values$generalTerm,
+                dim = 100,
+                iter = 20
+              )
+            }
+            w2v_model <- rf_results$w2v_model
           }
 
           # Aggregate word vectors to document vectors
           feature_matrix <- aggregateW2V_forRF(
             dfTag = values$dfTag,
-            w2v_model = values$w2v_model,
+            w2v_model = w2v_model,
             method = input$rf_w2v_aggregation,
             term = values$generalTerm
           )
@@ -787,14 +798,19 @@ docClassificationServer <- function(input, output, session, values) {
             "Test Set Accuracy: ",
             sprintf("%.2f%%", eval_test$accuracy * 100),
             "\n",
-            "OOB Error: ",
-            sprintf("%.2f%%", rf_model$model$prediction.error * 100)
+            ## a probability forest reports the Brier score here, not a
+            ## misclassification rate — label it for what it is
+            "OOB Brier score: ",
+            sprintf("%.4f", rf_model$model$prediction.error)
           ),
           type = "success"
         )
       },
       error = function(e) {
         removeNotification(id = "rf_training_notification")
+        ## without this the results panel keeps showing the PREVIOUS model,
+        ## as if the failed run had produced it
+        rf_results$trained <- FALSE
         sendSweetAlert(
           session = session,
           title = "Error Training Model",
@@ -869,12 +885,17 @@ docClassificationServer <- function(input, output, session, values) {
     cat(sprintf("Number of Features: %d\n", ncol(rf_results$train_data) - 1))
     cat(sprintf("Training Set Size: %d\n", nrow(rf_results$train_data)))
     cat(sprintf("Test Set Size: %d\n", nrow(rf_results$test_data)))
+    ## `prediction.error` of a probability forest is the OOB BRIER SCORE, not
+    ## a misclassification rate: printing it as "OOB Prediction Error (%)"
+    ## invited reading 0.21 as 21% of documents misclassified
     cat(sprintf(
-      "\nOOB Prediction Error: %.2f%%\n",
-      rf_results$model$prediction.error * 100
+      "\nOOB Brier Score: %.4f\n",
+      rf_results$model$prediction.error
     ))
+    ## and this one is computed on IN-SAMPLE predictions, so it is optimistic
+    ## by construction — say so rather than let it read as a held-out score
     cat(sprintf(
-      "Train Set Accuracy: %.2f%%\n",
+      "Train Set Accuracy (in-sample): %.2f%%\n",
       rf_results$eval_train$accuracy * 100
     ))
     cat(sprintf(
@@ -953,9 +974,12 @@ checkClassificationPrereqs <- function(values) {
   }
 
   # Check for selected documents
+  ## na.rm: an NA anywhere in docSelected makes sum() return NA, and `if (NA)`
+  ## aborts the whole prerequisite check with "missing value where TRUE/FALSE
+  ## needed" instead of reporting anything
   if (
     !"docSelected" %in% names(values$dfTag) ||
-      sum(values$dfTag$docSelected) == 0
+      sum(values$dfTag$docSelected, na.rm = TRUE) == 0
   ) {
     errors <- c(
       errors,
@@ -1578,7 +1602,7 @@ exportClassificationResults <- function(rf_results, filename, label_var) {
       "Number of Features",
       "Training Set Size",
       "Test Set Size",
-      "OOB Error (%)",
+      "OOB Brier Score",
       "Train Accuracy (%)",
       "Test Accuracy (%)"
     ),
@@ -1588,7 +1612,7 @@ exportClassificationResults <- function(rf_results, filename, label_var) {
       ncol(rf_results$train_data) - 1,
       nrow(rf_results$train_data),
       nrow(rf_results$test_data),
-      round(rf_results$model$prediction.error * 100, 2),
+      round(rf_results$model$prediction.error, 4),
       round(rf_results$eval_train$accuracy * 100, 2),
       round(rf_results$eval_test$accuracy * 100, 2)
     )
@@ -1643,8 +1667,13 @@ exportClassificationResults <- function(rf_results, filename, label_var) {
     apply(rf_results$test_pred$predictions, 1, which.max)
   ]
 
+  ## `.target_class` is the name the model frame uses (see trainRangerRF).
+  ## Reading `$target` matched nothing — or, on a corpus containing a term whose
+  ## sanitised column name is exactly "target", matched that TF-IDF column and
+  ## exported its numbers as if they were the true labels. `[[` also avoids the
+  ## partial matching that made the second case possible.
   predictions_data <- tibble(
-    Actual = as.character(rf_results$test_data$target),
+    Actual = as.character(rf_results$test_data[[".target_class"]]),
     Predicted = test_pred_classes,
     Correct = Actual == Predicted
   )

--- a/inst/tall/documents.R
+++ b/inst/tall/documents.R
@@ -3603,8 +3603,19 @@ documentsServer <- function(input, output, session, values, statsValues) {
       input$d_summarizationApply
     },
     valueExpr = {
+      ## The picker lists ORIGINAL document ids when the unit is "Documents"
+      ## (ids() calls backToOriginalGroups first), so the frame handed to
+      ## textrankDocument has to be un-grouped too. On a grouped corpus the
+      ## DEFAULT option otherwise selects an id that is not in values$dfTag and
+      ## the view dies inside textrank_sentences with
+      ## `nrow(data) > 1 is not TRUE`.
+      dfSummarize <- if (identical(input$unit_selection, "Groups")) {
+        values$dfTag
+      } else {
+        backToOriginalGroups(values$dfTag)
+      }
       values$docExtracted <- textrankDocument(
-        values$dfTag,
+        dfSummarize,
         id = input$document_selection
       )
       values$docExtraction <- abstractingDocument(

--- a/inst/tall/documents.R
+++ b/inst/tall/documents.R
@@ -1795,7 +1795,7 @@ documentsServer <- function(input, output, session, values, statsValues) {
         list(name = "Arun 2010", col = "Arun2010", decreasing = FALSE,
              desc = "KL divergence between word-topic and doc-topic distributions. Lower = better fit."),
         list(name = "Deveaud 2014", col = "Deveaud2014", decreasing = TRUE,
-             desc = "Jensen-Shannon divergence between topic pairs. Lower = more separated topics."),
+             desc = "Jensen-Shannon divergence between topic pairs. Higher = more separated topics."),
         list(name = "Perplexity", col = "Perplexity", decreasing = TRUE,
              desc = "Predictive performance on held-out data. Lower = better generalization.")
       )

--- a/inst/tall/featureroles.R
+++ b/inst/tall/featureroles.R
@@ -629,7 +629,9 @@ featureRolesServer <- function(input, output, session, values) {
   aggregateTimeVar <- function(date_values, aggregation) {
     switch(
       aggregation,
-      "day" = as.character(date_values),
+      ## as.character() on a POSIXct keeps the clock time, so "Day" produced
+      ## one period per second instead of one per day
+      "day" = format(date_values, "%Y-%m-%d"),
       "week" = format(date_values, "%Y-W%V"),
       "month" = format(date_values, "%Y-%m"),
       "quarter" = paste0(format(date_values, "%Y"), "-", quarters(date_values)),
@@ -666,7 +668,9 @@ featureRolesServer <- function(input, output, session, values) {
       )
 
       agg_values <- aggregateTimeVar(var_data, aggregation)
-      freq_table <- sort(table(agg_values, useNA = "ifany"))
+      ## table() keeps the period keys in chronological order (they are
+      ## zero-padded); sort() would have re-ordered them by document count
+      freq_table <- table(agg_values, useNA = "ifany")
       unique_periods <- length(freq_table)
 
       # Create table rows for time periods
@@ -1082,6 +1086,61 @@ featureRolesServer <- function(input, output, session, values) {
   observeEvent(input$applyVarRoles, {
     success_message <- ""
 
+    # Validate the keyness groups BEFORE assigning any role: the checks below
+    # abort with return(), and they used to run after the time and label roles
+    # had already been written, leaving a half-applied assignment behind.
+    # The categories come from the same doc-level, docSelected-filtered set the
+    # group pickers offer (output$keynessGroupAssignment), so the branch taken
+    # here and the choices shown there cannot disagree under an active filter.
+    keyness_categories <- NULL
+    if (!is.null(input$keynessVarInput) && input$keynessVarInput != "") {
+      keyness_doc_data <- values$dfTag %>%
+        filter(docSelected) %>%
+        group_by(doc_id) %>%
+        summarise(
+          var_value = first(.data[[input$keynessVarInput]]),
+          .groups = "drop"
+        )
+      keyness_categories <- sort(unique(keyness_doc_data$var_value[
+        !is.na(keyness_doc_data$var_value)
+      ]))
+
+      if (length(keyness_categories) > 2) {
+        if (
+          is.null(input$keynessGroup1Categories) ||
+            length(input$keynessGroup1Categories) == 0 ||
+            is.null(input$keynessGroup2Categories) ||
+            length(input$keynessGroup2Categories) == 0
+        ) {
+          sendSweetAlert(
+            session = session,
+            title = "Group Assignment Required",
+            text = "Please assign categories to both Group 1 and Group 2 before applying roles.",
+            type = "warning"
+          )
+          return()
+        }
+
+        overlap <- intersect(
+          input$keynessGroup1Categories,
+          input$keynessGroup2Categories
+        )
+
+        if (length(overlap) > 0) {
+          sendSweetAlert(
+            session = session,
+            title = "Error",
+            text = paste(
+              "Categories cannot belong to both groups. Overlapping categories:",
+              paste(overlap, collapse = ", ")
+            ),
+            type = "error"
+          )
+          return()
+        }
+      }
+    }
+
     # Apply Time Variable
     if (!is.null(input$timeVarInput) && input$timeVarInput != "") {
       values$timeVariable <- input$timeVarInput
@@ -1121,18 +1180,33 @@ featureRolesServer <- function(input, output, session, values) {
       values$keynessVariable <- input$keynessVarInput
 
       var_data <- values$dfTag[[input$keynessVarInput]]
-      categories <- unique(var_data[!is.na(var_data)])
+      categories <- keyness_categories
 
       if (length(categories) == 2) {
         # Automatically create keyness_group for binary variables
         keyness_group <- as.numeric(factor(var_data, levels = sort(categories)))
         values$dfTag$keyness_group <- keyness_group
 
-        # Count documents per group
+        # Count documents per group. drop_na + the guards below matter when the
+        # variable has missing values: without them the NA group adds a row,
+        # `doc_groups$n[doc_groups$keyness_group == 1]` returns c(n, NA), and
+        # the length-2 success_message makes the final if() throw.
         doc_groups <- values$dfTag %>%
+          filter(!is.na(keyness_group)) %>%
           group_by(doc_id, keyness_group) %>%
           summarise(.groups = "drop") %>%
           count(keyness_group)
+
+        n_group1 <- ifelse(
+          1 %in% doc_groups$keyness_group,
+          doc_groups$n[doc_groups$keyness_group == 1],
+          0
+        )
+        n_group2 <- ifelse(
+          2 %in% doc_groups$keyness_group,
+          doc_groups$n[doc_groups$keyness_group == 2],
+          0
+        )
 
         success_message <- paste0(
           success_message,
@@ -1140,49 +1214,16 @@ featureRolesServer <- function(input, output, session, values) {
           "<small>Group 1: ",
           sort(categories)[1],
           " (",
-          doc_groups$n[doc_groups$keyness_group == 1],
+          n_group1,
           " documents)<br>",
           "Group 2: ",
           sort(categories)[2],
           " (",
-          doc_groups$n[doc_groups$keyness_group == 2],
+          n_group2,
           " documents)</small><br>"
         )
       } else if (length(categories) > 2) {
-        # Check if groups have been assigned
-        if (
-          is.null(input$keynessGroup1Categories) ||
-            length(input$keynessGroup1Categories) == 0 ||
-            is.null(input$keynessGroup2Categories) ||
-            length(input$keynessGroup2Categories) == 0
-        ) {
-          sendSweetAlert(
-            session = session,
-            title = "Group Assignment Required",
-            text = "Please assign categories to both Group 1 and Group 2 before applying roles.",
-            type = "warning"
-          )
-          return()
-        }
-
-        # Check for overlap
-        overlap <- intersect(
-          input$keynessGroup1Categories,
-          input$keynessGroup2Categories
-        )
-
-        if (length(overlap) > 0) {
-          sendSweetAlert(
-            session = session,
-            title = "Error",
-            text = paste(
-              "Categories cannot belong to both groups. Overlapping categories:",
-              paste(overlap, collapse = ", ")
-            ),
-            type = "error"
-          )
-          return()
-        }
+        # the group assignment was validated at the top of the observer
 
         # Check if all categories are assigned
         assigned_categories <- c(

--- a/inst/tall/overview.R
+++ b/inst/tall/overview.R
@@ -1667,13 +1667,17 @@ overviewServer <- function(input, output, session, values, statsValues) {
     # Parse feats column (format: "Number=Plur|Tense=Past|Mood=Ind")
     # Extract values for the requested feature
     pattern <- paste0("(?:^|\\|)", feature_name, "=([^|]+)")
-    matches <- regmatches(feats_col, regexpr(pattern, feats_col, perl = TRUE))
+    # NB: regmatches() returns a COMPACTED vector (matching elements only), so a
+    # mask derived from it is all-TRUE and shorter than feats_col; indexing the
+    # full-length result with it made R recycle the mask and spray the matched
+    # values cyclically over every row. Build the mask from regexpr() on the FULL
+    # vector instead, so non-matching rows stay NA.
+    m <- regexpr(pattern, feats_col, perl = TRUE)
+    matches <- regmatches(feats_col, m)
     values <- sub(paste0(".*", feature_name, "="), "", matches)
-    values[matches == ""] <- NA
     # Handle non-matching rows
     result <- rep(NA_character_, length(feats_col))
-    has_match <- nchar(matches) > 0
-    result[has_match] <- values[has_match]
+    result[m > 0] <- values
     return(result)
   }
 

--- a/inst/tall/settings.R
+++ b/inst/tall/settings.R
@@ -532,8 +532,12 @@ settingsServer <- function(input, output, session, values, statsValues) {
   observeEvent(input$gemini_api_model, {
     if (!is.null(input$gemini_api_model)) {
       saveGeminiModel(
-        model = c(input$gemini_api_model, input$gemini_output_model),
-        file = paste0(homeFolder(), "/.tall_gemini_model.txt", collapse = "")
+        ## `input$gemini_output_model` does not exist (the control is
+        ## `gemini_output_size`), so this used to write a one-line file and
+        ## drop the output size. And the file went to ~/ while resetValues()
+        ## reads ~/tall/ — so nothing chosen here ever survived a restart.
+        model = c(input$gemini_api_model, input$gemini_output_size),
+        file = geminiModelFile()
       )
       values$gemini_api_model <- input$gemini_api_model
       values$gemini_output_size <- input$gemini_output_size
@@ -556,7 +560,7 @@ settingsServer <- function(input, output, session, values, statsValues) {
     if (!is.null(input$gemini_output_size)) {
       saveGeminiModel(
         model = c(input$gemini_api_model, input$gemini_output_size),
-        file = paste0(homeFolder(), "/.tall_gemini_model.txt", collapse = "")
+        file = geminiModelFile()
       )
       values$gemini_api_model <- input$gemini_api_model
       values$gemini_output_size <- input$gemini_output_size

--- a/inst/tall/settings.R
+++ b/inst/tall/settings.R
@@ -471,16 +471,26 @@ settingsServer <- function(input, output, session, values, statsValues) {
       selectInput(
         inputId = "gemini_api_model",
         label = "Select the Gemini Model",
-        choices = c(
-          "Gemini 2.5 Flash" = "2.5-flash",
-          "Gemini 2.5 Flash Lite" = "2.5-flash-lite",
-          "Gemini 3.0 Flash" = "3-flash-preview",
-          "Gemini 3.1 Pro" = "3.1-pro-preview",
-          "Gemini Pro Latest" = "pro-latest"
+        ## Two rules, both learned the hard way (2026-08-15):
+        ##  - no PREVIEW ids. "3-flash-preview" and "3.1-pro-preview" were
+        ##    offered here and carry their own expiry date.
+        ##  - the 2.5 pair is no longer anyone's default. Google stopped
+        ##    serving it to newly created API keys, so a new user starting
+        ##    there could not run a single analysis. Keys made before the
+        ##    cut-off still reach it, so it stays selectable under Legacy.
+        ## `-latest` aliases are the only ids that cannot go stale.
+        choices = list(
+          "Gemini 3.5 Flash Lite" = "3.5-flash-lite",
+          "Gemini Flash Latest" = "flash-latest",
+          "Gemini Pro Latest" = "pro-latest",
+          "Legacy (older API keys only)" = c(
+            "Gemini 2.5 Flash" = "2.5-flash",
+            "Gemini 2.5 Flash Lite" = "2.5-flash-lite"
+          )
         ),
         selected = ifelse(
           is.null(values$gemini_api_model),
-          "2.5-flash-lite",
+          "3.5-flash-lite",
           values$gemini_api_model
         )
       ),
@@ -507,18 +517,29 @@ settingsServer <- function(input, output, session, values, statsValues) {
         ))
       ),
       conditionalPanel(
-        condition = "input.gemini_api_model == '3-flash-preview'",
+        condition = "input.gemini_api_model == '3.5-flash-lite'",
+        helpText(strong("Free Tier Rate Limits:")),
+        helpText(em(
+          "Request per Minutes: 15",
+          tags$br(),
+          "Requests per Day: 500",
+          tags$br(),
+          "Latency time: Low"
+        ))
+      ),
+      conditionalPanel(
+        condition = "input.gemini_api_model == 'flash-latest'",
         helpText(strong("Free Tier Rate Limits:")),
         helpText(em(
           "Request per Minutes: 10",
           tags$br(),
-          "Requests per Day: 500",
+          "Requests per Day: 250",
           tags$br(),
           "Latency time: Medium"
         ))
       ),
       conditionalPanel(
-        condition = "input.gemini_api_model == '3.1-pro-preview' || input.gemini_api_model == 'pro-latest'",
+        condition = "input.gemini_api_model == 'pro-latest'",
         helpText(strong(style = "color: #d9534f;", "Paid API Key Required")),
         helpText(em(
           "Pro models require a paid (non-free tier) API key.",
@@ -543,7 +564,7 @@ settingsServer <- function(input, output, session, values, statsValues) {
       values$gemini_output_size <- input$gemini_output_size
 
       # Alert for Pro models requiring paid API key
-      if (input$gemini_api_model %in% c("3.1-pro-preview", "pro-latest")) {
+      if (input$gemini_api_model %in% c("pro-latest")) {
         showModal(modalDialog(
           title = "Paid API Key Required",
           tags$p("The selected Pro model requires a ", tags$strong("paid (non-free tier)"), " Google AI API key."),
@@ -590,21 +611,29 @@ settingsServer <- function(input, output, session, values, statsValues) {
       output$status <- renderText("\u231b Validating API key...")
     })
 
-    # Async: validate key via API call in background
+    ## Async: validate the key against the model CATALOGUE, in background.
+    ##
+    ## It used to send a generateContent "Hello" to a hard-coded "2.5-flash"
+    ## and then collapse ANY status from 100 to 599 with
+    ## grepl("HTTP\\s*[1-5][0-9]{2}") into one message — so a retired-model 404,
+    ## a 429 quota, a 503 overload and a genuine bad key all came out as "API
+    ## key seems be not valid". When Google stopped serving 2.5 to new keys,
+    ## that made every new user's perfectly good key look rejected
+    ## (bibliometrix PR #637, same defect).
+    ##
+    ## geminiValidateKey() asks about the KEY (does the catalogue come back?)
+    ## and about the MODEL (is the chosen one in it?) separately, and returns
+    ## Google's own message when it refuses.
+    chosen <- values$gemini_api_model
     promises::future_promise({
-      apiCheck <- gemini_ai(
-        image = NULL, prompt = "Hello", model = "2.5-flash",
-        type = "png", retry_503 = 5, api_key = key
-      )
-      contains_error <- grepl("HTTP\\s*[1-5][0-9]{2}", apiCheck)
-      list(valid = !contains_error, key = key)
+      res <- geminiValidateKey(key, model = chosen)
+      list(valid = res$valid, key = key, message = res$message,
+           model_available = res$model_available)
     }, seed = TRUE) %...>%
       (function(result) {
         if (!result$valid) {
           output$apiStatus <- renderUI({
-            output$status <- renderText(
-              "\u274c API key seems be not valid! Please, check it or your connection."
-            )
+            output$status <- renderText(result$message)
           })
           values$geminiAPI <- FALSE
         } else {
@@ -618,9 +647,20 @@ settingsServer <- function(input, output, session, values, statsValues) {
             paste0(rep("*", nchar(result$key) - 4), collapse = ""),
             last4
           )
+          ## the key is good either way; the model is a separate sentence, so
+          ## a wrong choice is discovered HERE and not as a 404 at the first
+          ## analysis
+          note <- if (isFALSE(result$model_available)) {
+            paste0(
+              "\n\u26a0 The selected model (gemini-", chosen,
+              ") is not available for this API key. Please pick another one above."
+            )
+          } else {
+            ""
+          }
           output$apiStatus <- renderUI({
             output$status <- renderText(
-              paste0("\u2705 API key has been set: ", masked)
+              paste0("\u2705 API key has been set: ", masked, note)
             )
           })
           values$geminiAPI <- TRUE

--- a/inst/tall/tallAI.R
+++ b/inst/tall/tallAI.R
@@ -1,8 +1,16 @@
 #### Google GEMINI API ####
+## Model ids are stored WITHOUT the "gemini-" prefix: the URL is built with
+## paste0("gemini-", model, ...) below.
+##
+## ⚠ A THIRD-PARTY MODEL ID IS A VALUE THAT EXPIRES. This default was
+## "2.5-flash-lite" until 2026-08-15, when Google stopped serving the whole 2.5
+## family to newly created API keys ("404 ... no longer available to new
+## users"). Nothing here should depend on a particular model still existing —
+## see .geminiAvailableModels(), which validates a key against the CATALOGUE.
 gemini_ai <- function(
   image = NULL,
   prompt = "Explain these images",
-  model = "2.5-flash-lite",
+  model = "3.5-flash-lite",
   type = "png",
   retry_503 = 5,
   api_key = NULL,
@@ -105,25 +113,33 @@ gemini_ai <- function(
       req_headers("Content-Type" = "application/json") |>
       req_body_json(request_body)
 
+    ## req_error(): tell httr2 NOT to throw on 4xx/5xx, so `resp` is a real
+    ## response and resp_body_string() below can read Google's own message.
+    ## Without it every error arrived as a hand-built list, resp_body_string()
+    ## failed on it, and the fallback text was shown instead of the real reason
+    ## — which is how a retired-model 404 came out as "check your API key".
     resp <- tryCatch(
-      req_perform(req),
+      req |> req_error(is_error = function(resp) FALSE) |> req_perform(),
       error = function(e) {
-        return(list(
-          status_code = stringr::str_extract(e$message, "(?<=HTTP )\\d+") |>
-            as.numeric(),
-          error = TRUE,
-          message = paste("❌ Request failed with error:", e$message)
-        ))
+        list(transport_error = TRUE, message = conditionMessage(e))
       }
     )
 
-    # # Handle connection-level error
-    # if (is.list(resp) && isTRUE(resp$error)) {
-    #   return(resp$message)
-    # }
+    ## A genuine transport failure (DNS, proxy, TLS, timeout): there is no HTTP
+    ## status at all. This branch used to be COMMENTED OUT, which left
+    ## status_code = NA, made `if (resp$status_code == 400)` below evaluate
+    ## `if (NA)`, and showed the user the R error "missing value where
+    ## TRUE/FALSE needed" instead of "there is no connection".
+    if (!inherits(resp, "httr2_response")) {
+      return(paste0(
+        "❌ Connection failed: ", resp$message,
+        "\nThis is a connection problem, not your API key."
+      ))
+    }
+    status <- httr2::resp_status(resp)
 
     # Retry on HTTP 503 or 429
-    if (resp$status_code %in% c(429, 503)) {
+    if (status %in% c(429, 503)) {
       if (attempt < retry_503) {
         message(paste0(
           "⚠️ HTTP 503 (Service Unavailable) - retrying in 2 seconds (attempt ",
@@ -147,33 +163,32 @@ gemini_ai <- function(
       }
     }
 
-    # HTTP errors
-    # 400 api key not valid
-    if (resp$status_code == 400) {
+    ## Google's own message, which now actually arrives (see req_error above)
+    if (status != 200) {
       msg <- tryCatch(
         {
           parsed <- jsonlite::fromJSON(httr2::resp_body_string(resp))
           parsed$error$message
         },
-        error = function(e) {
-          "Please check your API key. It seems to be not valid!"
-        }
+        error = function(e) "no further detail was returned"
       )
-      return(paste0("❌ HTTP ", resp$status_code, ": ", msg))
-    }
-    # Other HTTP errors
-    if (resp$status_code != 200) {
-      msg <- tryCatch(
-        {
-          parsed <- jsonlite::fromJSON(httr2::resp_body_string(resp))
-          parsed$error$message
-        },
-        error = function(e) {
-          "Service unavailable or unexpected error. Please check your API key and usage limit."
-        }
-      )
-
-      return(paste0("❌ HTTP ", resp$status_code, ": ", msg))
+      ## Only the statuses that really mean "this key" mention the key. A 404
+      ## is a model that does not exist for this key, a 403 a permission, a 429
+      ## a quota — telling the user to check their key in those cases sends
+      ## them to fix something that is not broken.
+      hint <- if (status %in% c(400, 401)) {
+        "\nPlease check your API key. It seems to be not valid!"
+      } else if (status == 403) {
+        "\nThis API key is not allowed to use this resource."
+      } else if (status == 404) {
+        paste0(
+          "\nThe model \"gemini-", model, "\" is not available for this API key.",
+          "\nPick another model in Settings > Tall AI."
+        )
+      } else {
+        ""
+      }
+      return(paste0("❌ HTTP ", status, ": ", msg, hint))
     }
 
     # Successful response
@@ -183,59 +198,123 @@ gemini_ai <- function(
   }
 }
 
-setGeminiAPI <- function(api_key) {
-  # 1. Controllo validità dell'API key
-  apiCheck <- gemini_ai(
-    image = NULL,
-    prompt = "Hello",
-    model = "2.5-flash",
-    type = "png",
-    retry_503 = 5,
-    api_key = api_key
-  )
+## ---------------------------------------------------------------------------
+## Key validation — model-agnostic
+## ---------------------------------------------------------------------------
+## `setGeminiAPI()` used to live here. It validated a key by sending a real
+## generateContent "Hello" to a HARD-CODED "2.5-flash", and it had no callers
+## anywhere in the package: a dead copy of the logic that was inlined into
+## settings.R. Both carried the same defect, so both are gone — a duplicate
+## nobody reaches is a bug waiting for someone to re-wire it.
+##
+## THE DEFECT (bibliometrix PR #637, carried across 2026-08-15). Probing a named
+## model conflates two different questions — "is this key good?" and "does that
+## model still exist for this key?" — and answers the first wrongly as soon as
+## the second changes. Google stopped serving the 2.5 family to newly created
+## API keys, so the probe returned 404 and EVERY new user was told their key had
+## been refused, whatever model they had chosen in Settings.
+##
+## The catalogue endpoint (ListModels) has no such expiry: it answers about the
+## KEY. Which models exist is then a separate question, answered from the same
+## reply, and reported rather than treated as a refusal.
 
-  contains_http_error <- grepl("HTTP\\s*[1-5][0-9]{2}", apiCheck)
+.geminiAvailableModels <- function(api_key = NULL, timeout = 60,
+                                   endpoint = getOption(
+                                     "tall.gemini_endpoint",
+                                     "https://generativelanguage.googleapis.com/v1beta/models"
+                                   )) {
+  if (is.null(api_key)) api_key <- Sys.getenv("GEMINI_API_KEY")
 
-  if (contains_http_error) {
-    return(list(
-      valid = FALSE,
-      message = "❌ API key seems be not valid! Please, check it or your connection."
-    ))
-  }
+  models <- character(0)
+  page <- NULL
 
-  if (is.null(api_key) || !is.character(api_key) || nchar(api_key) == 0) {
-    return(list(
-      valid = FALSE,
-      message = "❌ API key must be a non-empty string."
-    ))
-  }
+  for (i in seq_len(10)) {                       # a page cap, not a real limit
+    ## `endpoint` is an option so this can be pointed at a local stub and
+    ## checked without a key of any value and without spending a quota
+    req <- request(endpoint) |>
+      req_url_query(key = api_key, pageSize = 200) |>
+      req_timeout(timeout) |>
+      req_error(is_error = function(resp) FALSE)
+    if (!is.null(page)) req <- req |> req_url_query(pageToken = page)
 
-  if (nchar(api_key) < 10) {
-    return(list(
-      valid = FALSE,
-      message = "❌ API key seems too short. Please verify your key."
-    ))
-  }
-
-  # 2. Mostra solo gli ultimi 4 caratteri per feedback
-  last_chars <- 4
-  last <- substr(
-    api_key,
-    max(1, nchar(api_key) - last_chars + 1),
-    nchar(api_key)
-  )
-
-  # 3. Imposta la variabile d'ambiente
-  Sys.setenv(GEMINI_API_KEY = api_key)
-
-  return(list(
-    valid = TRUE,
-    message = paste0(
-      paste0(rep("*", nchar(api_key) - 4), collapse = ""),
-      last,
-      collapse = ""
+    resp <- tryCatch(
+      req_perform(req),
+      error = function(e) {
+        list(transport_error = TRUE, message = conditionMessage(e))
+      }
     )
-  ))
+
+    if (!inherits(resp, "httr2_response")) {
+      return(list(
+        valid = FALSE, connection = TRUE, models = character(0),
+        message = paste0(
+          "\u274c Connection failed: ", resp$message,
+          "\nThis is a connection problem, not your API key."
+        )
+      ))
+    }
+
+    status <- httr2::resp_status(resp)
+    if (status != 200) {
+      msg <- tryCatch(
+        jsonlite::fromJSON(httr2::resp_body_string(resp))$error$message,
+        error = function(e) "no further detail was returned"
+      )
+      return(list(
+        valid = FALSE, connection = FALSE, models = character(0),
+        message = paste0(
+          "\u274c HTTP ", status, ": ", msg,
+          if (status %in% c(400, 401, 403)) {
+            "\nGoogle refused this API key."
+          } else {
+            ""
+          }
+        )
+      ))
+    }
+
+    body <- httr2::resp_body_json(resp)
+    for (m in body$models) {
+      methods <- unlist(m$supportedGenerationMethods)
+      ## when the field is absent, take the model at its word
+      if (is.null(methods) || "generateContent" %in% methods) {
+        models <- c(models, sub("^models/", "", m$name))
+      }
+    }
+    page <- body$nextPageToken
+    if (is.null(page)) break
+  }
+
+  list(valid = TRUE, connection = FALSE, models = models, message = "")
+}
+
+## Is this key good, and does it carry the model the user has chosen?
+## Two answers, kept apart: a model missing from the catalogue is REPORTED,
+## never a refusal — the key works, it is the choice that is wrong, and the
+## user hears it in Settings instead of as a 404 at the first analysis.
+geminiValidateKey <- function(api_key, model = NULL) {
+  if (is.null(api_key) || !is.character(api_key) || nchar(api_key) == 0) {
+    return(list(valid = FALSE, model_available = NA,
+                message = "\u274c API key must be a non-empty string."))
+  }
+  if (nchar(api_key) < 10) {
+    return(list(valid = FALSE, model_available = NA,
+                message = "\u274c API key seems too short. Please verify your key."))
+  }
+
+  res <- .geminiAvailableModels(api_key)
+  if (!isTRUE(res$valid)) {
+    return(list(valid = FALSE, model_available = NA, message = res$message))
+  }
+
+  ## ids are stored without the "gemini-" prefix; the catalogue carries it
+  available <- NA
+  if (!is.null(model) && nzchar(model)) {
+    available <- paste0("gemini-", model) %in% res$models
+  }
+
+  list(valid = TRUE, models = res$models, model_available = available,
+       message = "")
 }
 
 showGeminiAPI <- function() {
@@ -278,12 +357,22 @@ loadGeminiModel = function(file) {
   if (file.exists(file)) {
     model <- readLines(file, warn = FALSE)
   } else {
-    model <- c("2.5-flash", "medium")
+    ## every FIRST-RUN user lands here. It said "2.5-flash" until 2026-08-15,
+    ## which is a family Google no longer serves to new API keys — so a new
+    ## user's very first request 404'd, and the app blamed their key
+    model <- c("3.5-flash-lite", "medium")
   }
   ## was `length(model == 1)`: length() of a LOGICAL vector, so always >= 1 and
   ## the branch always ran, appending a third element to a complete pair
   if (length(model) == 1) {
     model <- c(model, "medium")
+  }
+  ## a stored "2.5-flash" is almost never a deliberate choice — it was the old
+  ## DEFAULT, written out the first time the user touched Settings. Carrying it
+  ## forward is kinder than leaving them on a model that 404s; anyone who
+  ## actually wants 2.5 can pick it again from the Legacy group.
+  if (identical(model[1], "2.5-flash")) {
+    model[1] <- "3.5-flash-lite"
   }
   return(model)
 }

--- a/inst/tall/tallAI.R
+++ b/inst/tall/tallAI.R
@@ -265,6 +265,14 @@ load_api_key <- function(path = path_gemini_key) {
   return(FALSE)
 }
 
+## the ONE place that knows where the model choice lives. It used to be written
+## to ~/.tall_gemini_model.txt (settings.R) and read from
+## ~/tall/.tall_gemini_model.txt (resetValues), so the choice was lost at every
+## restart and TALL always came back on 2.5-flash / medium.
+geminiModelFile = function() {
+  file.path(homeFolder(), "tall", ".tall_gemini_model.txt")
+}
+
 loadGeminiModel = function(file) {
   # load info about model type and output size
   if (file.exists(file)) {
@@ -272,7 +280,9 @@ loadGeminiModel = function(file) {
   } else {
     model <- c("2.5-flash", "medium")
   }
-  if (length(model == 1)) {
+  ## was `length(model == 1)`: length() of a LOGICAL vector, so always >= 1 and
+  ## the branch always ran, appending a third element to a complete pair
+  if (length(model) == 1) {
     model <- c(model, "medium")
   }
   return(model)

--- a/inst/tall/tallEmbeddings.R
+++ b/inst/tall/tallEmbeddings.R
@@ -23,6 +23,18 @@ w2vTraining <- function(x, term = "lemma", dim = 100, iter = 20) {
   return(w2v_model)
 }
 
+## word2vec always carries a "</s>" sentence-boundary sentinel in the model
+## matrix. It is not a word of the corpus and its vector is essentially
+## untrained: on Frankenstein its norm is 4.47 against a mean absolute
+## component of 0.81 for real terms, which made it the Min or the Max in 10 of
+## the 20 dimensions of the Training tab, moved Kurtosis by up to 183 and
+## dropped the variance explained by PC1 from 0.591 to 0.501. Every consumer of
+## the model matrix goes through this helper instead of as.matrix().
+w2vMatrix <- function(w2v_model) {
+  m <- as.matrix(w2v_model)
+  m[rownames(m) != "</s>", , drop = FALSE]
+}
+
 summary_stats_embeddings <- function(embedding_matrix, as_tibble = TRUE) {
   # Skewness personalizzata (corretta per bias)
   skewness_custom <- function(x) {
@@ -115,7 +127,7 @@ pca_analysis_embeddings <- function(embedding_matrix) {
 
 ## WORD EMBEDDING SIMILARITY ----
 w2vNetwork <- function(w2v_model, dfTag, term, n = 100) {
-  w2v_matrix <- as.matrix(w2v_model)
+  w2v_matrix <- w2vMatrix(w2v_model)
 
   ## similarity
   top_words <- dfTag %>%
@@ -129,12 +141,14 @@ w2vNetwork <- function(w2v_model, dfTag, term, n = 100) {
     tolower()
 
   # remove top_words felt in the stop_word list
-  top_words <- intersect(top_words, row.names(as.matrix(w2v_model)))
+  top_words <- intersect(top_words, row.names(w2v_matrix))
 
   similarity <- predict(w2v_model, newdata = top_words)
   df_similarity <- bind_rows(similarity) %>%
     select(-rank) %>%
-    rename(from = term1, to = term2)
+    rename(from = term1, to = term2) %>%
+    ## predict() searches the whole model, sentinel included
+    filter(to != "</s>")
 
   # Nodi unici
   nodes <- data.frame(
@@ -154,12 +168,30 @@ w2vNetwork <- function(w2v_model, dfTag, term, n = 100) {
     mutate(width = similarity * 10)
 
   ### COMMUNITY DETECTION
+  ## No pair of words reaching the threshold used to reach
+  ## graph_from_data_frame() with an empty edge list, and the rename() below
+  ## then failed with "Column `V1` doesn't exist".
+  if (nrow(edges) == 0) {
+    return(list(nodes = nodes[0, , drop = FALSE], edges = edges,
+                top_words = top_words))
+  }
+
   graph <- igraph::graph_from_data_frame(edges, directed = FALSE)
   cluster <- igraph::cluster_louvain(graph)
-  cluster_df <- data.frame(as.list(igraph::membership(cluster)))
-  cluster_df <- as.data.frame(t(cluster_df)) %>%
-    rownames_to_column(var = "id") %>%
-    rename(group = "V1")
+  membership <- igraph::membership(cluster)
+
+  ## This table used to be built as data.frame(as.list(membership)), which runs
+  ## make.names() over the vertex names: every term that is not a syntactic R
+  ## name lost the join below and was silently dropped from the plot. That is
+  ## not an exotic case — it covers hyphens and apostrophes ("e-mail"), a
+  ## leading digit ("3d", "30"), everything TALL's own entity tagging produces
+  ## (hashtags, mentions, emoji, URLs) and the reserved words, so ordinary
+  ## English terms such as "next", "break", "in" and "for" vanished too.
+  cluster_df <- data.frame(
+    id = names(membership),
+    group = as.integer(membership),
+    stringsAsFactors = FALSE
+  )
 
   # Create group column
   nodes <- left_join(nodes, cluster_df, by = "id") %>%
@@ -239,6 +271,19 @@ w2v2Vis <- function(
   labelsize = 35,
   overlap = "none"
 ) {
+  ## w2vNetwork() returns no node when no word pair reaches the threshold; say
+  ## so on the canvas instead of failing on max(nodes$group) of an empty vector
+  if (nrow(nodes) == 0) {
+    nodes <- data.frame(
+      id = "none",
+      label = "No pair of words reaches the similarity threshold",
+      shape = "text", size = 20, font.size = 35, group = 1L,
+      stringsAsFactors = FALSE
+    )
+    edges <- data.frame(from = character(0), to = character(0),
+                        stringsAsFactors = FALSE)
+  }
+
   nodes$font.size <- labelsize * 2.5
   nodes$size <- round(labelsize / 1.2, 0)
   nodes$font.vadjust = -20
@@ -283,7 +328,7 @@ w2v2Vis <- function(
 }
 
 w2vUMAP <- function(w2v_model, top_words) {
-  cbow_embedding <- as.matrix(w2v_model)
+  cbow_embedding <- w2vMatrix(w2v_model)
   visualization <- umap(cbow_embedding, n_neighbors = 15, n_threads = 2)
 
   df <- data.frame(
@@ -320,9 +365,13 @@ adjust_labels_iterative_with_opacity <- function(
 ) {
   df$opacity_val <- rep(0.9, nrow(df)) # inizialmente opacità massima
 
-  for (iter in seq_len(max_iter)) {
+  ## with a single label `1:(nrow(df) - 1)` counts DOWN to 0, so the loop below
+  ## indexed row 0 and the comparison failed with "missing value where
+  ## TRUE/FALSE needed". Nothing can overlap with itself: skip straight to the
+  ## colour assignment.
+  for (iter in seq_len(if (nrow(df) < 2) 0L else max_iter)) {
     overlap_found <- FALSE
-    for (i in 1:(nrow(df) - 1)) {
+    for (i in seq_len(nrow(df) - 1)) {
       for (j in (i + 1):nrow(df)) {
         dx <- df$x[i] - df$x[j]
         dy <- df$y[i] - df$y[j]

--- a/inst/tall/tallNLP.R
+++ b/inst/tall/tallNLP.R
@@ -1084,7 +1084,13 @@ noGroupLabels <- function(label) {
       "lemma_original",
       "upos_specialentities",
       "upos_original_custom",
-      "keyness_group"
+      "keyness_group",
+      ## derived by the Time role like keyness_group is by the Keyness one:
+      ## without it, applying a Date time variable makes tall's own
+      ## aggregation key show up as a user feature in Filters, Groups
+      ## (where groupByMetadata would re-key the documents by it), the STM
+      ## covariate list and Feature Roles itself
+      "time_agg"
     )
   )
 }

--- a/inst/tall/tallNLP.R
+++ b/inst/tall/tallNLP.R
@@ -367,6 +367,12 @@ rakeReset <- function(x) {
       rename(upos = upos_original)
   }
 
+  if ("POSSelected_original_nomultiwords" %in% names(x)) {
+    x <- x %>%
+      select(-"POSSelected") %>%
+      rename(POSSelected = POSSelected_original_nomultiwords)
+  }
+
   if ("lemma_original_nomultiwords" %in% names(x)) {
     x <- x %>%
       select(-"lemma") %>%
@@ -667,11 +673,32 @@ rake <- function(
     sep = " "
   )
 
-  # Operazioni vettorizzate (molto più veloci di mutate multiple)
+  # Il kernel azzera (NA) le posizioni assorbite da un multiword: sono i
+  # costituenti da marcare NGRAM_MERGED. Un termine gia' NA in partenza NON e'
+  # un costituente e va lasciato stare, quindi la condizione guarda term_col.
+  merged_away <- is.na(multiword) & !is.na(term_col)
+
+  # Quale keyword ha assorbito ogni costituente: e' l'ultimo multiword non-NA
+  # a monte (la testa precede sempre immediatamente la sua coda). Serve a
+  # applyRake() per riconoscere le code delle SOLE keyword selezionate.
+  owner <- multiword
+  owner[merged_away] <- NA_character_
+  last_head <- cummax(ifelse(is.na(owner), 0L, seq_along(owner)))
+  mw_owner <- ifelse(
+    merged_away & last_head > 0L,
+    owner[pmax(last_head, 1L)],
+    NA_character_
+  )
+
+  # Operazioni vettorizzate (molto più veloci di mutate multiple).
+  # ATTENZIONE: i due ifelse devono restare in QUESTO ordine. Annidarli
+  # all'inverso (test esterno term_col == multiword) rende irraggiungibile il
+  # ramo NGRAM_MERGED, perché su una posizione assorbita multiword è NA e
+  # ifelse(NA, ...) restituisce NA senza valutare i rami.
   upos_multiword <- ifelse(
-    term_col == multiword,
-    x2$upos,
-    ifelse(is.na(multiword), "NGRAM_MERGED", "MULTIWORD")
+    merged_away,
+    "NGRAM_MERGED",
+    ifelse(term_col == multiword, x2$upos, "MULTIWORD")
   )
 
   # Lookup diretto invece di join (più veloce)
@@ -684,6 +711,7 @@ rake <- function(
     multiword = multiword,
     upos_multiword = upos_multiword,
     ngram = unname(ngram_values),
+    mw_owner = mw_owner,
     stringsAsFactors = FALSE
   )
 
@@ -856,17 +884,32 @@ applyRake <- function(x, rakeResults, row_sel = NULL, term = "lemma") {
     x <- x %>% select(-"ngram")
   }
 
+  # I costituenti assorbiti vengono deselezionati (POSSelected = FALSE), quindi
+  # il "Back" deve poterli riselezionare: la selezione pre-multiword viene
+  # messa da parte una volta sola, come upos_original / *_nomultiwords.
+  if (!"POSSelected_original_nomultiwords" %in% names(x)) {
+    x$POSSelected_original_nomultiwords <- x$POSSelected
+  }
+
   # Filter stats based on selected rows
   rakeResults$stats <- rakeResults$stats[row_sel, ]
   selected_keywords <- rakeResults$stats$keyword
 
   # Filter dfMW - optimized logic
+  # Le righe NGRAM_MERGED hanno multiword NA (il kernel le azzera): vanno
+  # riconosciute tramite mw_owner, la keyword che le ha assorbite. Con il
+  # vecchio test su `multiword` cadevano sempre fuori e i costituenti
+  # tornavano nel corpus accanto al multiword.
+  if (!"mw_owner" %in% names(rakeResults$dfMW)) {
+    rakeResults$dfMW$mw_owner <- NA_character_
+  }
   rakeResults$dfMW <- rakeResults$dfMW %>%
     filter(
       (upos_multiword == "MULTIWORD" & multiword %in% selected_keywords) |
-        (upos_multiword == "NGRAM_MERGED" & multiword %in% selected_keywords) |
+        (upos_multiword == "NGRAM_MERGED" & mw_owner %in% selected_keywords) |
         (!upos_multiword %in% c("MULTIWORD", "NGRAM_MERGED"))
-    )
+    ) %>%
+    select(-"mw_owner")
 
   # Select term column once (avoid switch duplication)
   term_col <- if (term == "lemma") "lemma" else "token"

--- a/inst/tall/tallSentiment.R
+++ b/inst/tall/tallSentiment.R
@@ -1024,6 +1024,12 @@ create_document_box <- function(
 
 ### ABSTRACTIVE TEXT SUMMARIZATION: ----
 
+## ⚠ SUPERSEDED AND UNREACHABLE. The live abstractive summary is the inline
+## block at documents.R:3437+, which correctly uses values$gemini_api_model;
+## this function has no callers anywhere in the package. Its `model` default
+## was "2.0-flash" — a family Google retired even before 2.5 — so anyone
+## re-wiring it would have got a 404. Left in place with a live default rather
+## than deleted, but it is a duplicate and should probably go (2026-08-15).
 abstractive_summary <- function(
   values,
   input,
@@ -1031,7 +1037,7 @@ abstractive_summary <- function(
   nL = 250,
   maxTokens = 16384,
   api_key = NULL,
-  model = "2.0-flash",
+  model = "3.5-flash-lite",
   retry_attempts = 5
 ) {
   # Input validation

--- a/inst/tall/tallSentiment.R
+++ b/inst/tall/tallSentiment.R
@@ -814,11 +814,18 @@ textrankDocument <- function(dfTag, id) {
   s <- tr$sentences %>%
     arrange(desc(textrank))
 
+  ## Join on the sentence ID, not on its text (as highlightSentences() above
+  ## already does). Joining by `sentence` is a many-to-many join for any
+  ## document that repeats a sentence: the row count inflates by k^2 - k per
+  ## text repeated k times, every copy inherits every paragraph carrying that
+  ## text, and nrow(s) is the denominator abstractingDocument() takes its
+  ## percentages of. A 4-sentence tweet was rendered as 10 sentences.
   s <- s %>%
     left_join(
-      df %>% select(paragraph_id, sentence_id, sentence) %>% distinct(),
-      by = c("sentence")
-    )
+      df %>% select(paragraph_id, sentence_id) %>% distinct(),
+      by = c("textrank_id" = "sentence_id")
+    ) %>%
+    mutate(sentence_id = textrank_id)
   results <- list(
     s = s,
     id = id,

--- a/inst/tall/tallTextIO.R
+++ b/inst/tall/tallTextIO.R
@@ -710,7 +710,14 @@ wikiSearch <- function(term, n = 10) {
     "&prop=extracts&exintro&explaintext&exlimit=max&format=json&gsrsearch="
   )
 
-  term <- gsub("–", " ", gsub("\\s", "_", term))
+  ## The phrase goes into a URL, so it has to be percent-encoded: an "&" would
+  ## otherwise open a new API parameter (the search would silently run on the
+  ## part before it) and the space this very line can produce out of an en dash
+  ## makes the URL illegal, which aborts the import with a connection error.
+  term <- URLencode(
+    gsub("–", " ", gsub("\\s", "_", term)),
+    reserved = TRUE
+  )
 
   result <- jsonlite::fromJSON(paste0(
     search_url,
@@ -757,8 +764,11 @@ wikiExtract <- function(df) {
   items <- gsub("\\s", "_", df$title)
   for (i in 1:length(items)) {
     if (df$selected[i]) {
-      title <- items[i]
-      # print(title)
+      ## Same reason as in wikiSearch(): a title is not URL-safe. Any page whose
+      ## name carries a non-ASCII character (Zürich, Café, Pokémon…) made the
+      ## API answer 400 Bad Request, and since one bad page stops the loop the
+      ## whole import came back empty.
+      title <- URLencode(items[i], reserved = TRUE)
       result <- jsonlite::fromJSON(paste0(
         "https://en.wikipedia.org/w/api.php?action=query&titles=",
         title,

--- a/inst/tall/tallTopicModel.R
+++ b/inst/tall/tallTopicModel.R
@@ -119,6 +119,14 @@ evaluate_tm_parallel <- function(
   return(list(metrics = metrics, models = models))
 }
 
+## NOTE: `decreasing` does not change the result, and is kept only so that
+## callers can state which way a metric runs. Negating the metric reflects the
+## whole configuration about the x axis, and the distance from a point to a
+## line is invariant under reflection — so `distances`, and therefore
+## `which.max(distances)`, are identical either way. Verified by execution on
+## 2000 random metric shapes: the same k came back 2000/2000 times. The knee of
+## a curve is the knee whichever end of it is the good end; do not "fix" the
+## flags expecting the recommendation to move.
 find_elbow <- function(k, metric, decreasing = TRUE, plot = TRUE) {
   # Normalizza i dati
   x <- as.numeric(scale(k))
@@ -413,19 +421,24 @@ tmConsensusK <- function(metrics_df, method = "LDA") {
 tmMultiMetricPlot <- function(result, method = "LDA") {
   df <- result$metrics %>% rename(topics = k)
 
+  # `higher_better` says which end of a metric is the good end. It used to be
+  # called `decreasing` and was set as though it meant "lower is better", while
+  # the branch below treats it as "higher is better" — so two curves in each
+  # method were drawn upside down against this plot's own y axis, which reads
+  # "0 = worst, 1 = best". It does NOT affect the recommended K: see find_elbow.
   if (method == "STM") {
     metric_info <- list(
-      list(col = "CaoJuan2009", label = "Exclusivity", color = "#e74c3c", decreasing = TRUE),
-      list(col = "Arun2010", label = "Semantic Coherence", color = "#3498db", decreasing = FALSE),
-      list(col = "Deveaud2014", label = "Excl. + Coherence", color = "#2ecc71", decreasing = TRUE),
-      list(col = "logLik", label = "Lower Bound", color = "#9b59b6", decreasing = FALSE)
+      list(col = "CaoJuan2009", label = "Exclusivity", color = "#e74c3c", higher_better = TRUE),
+      list(col = "Arun2010", label = "Semantic Coherence", color = "#3498db", higher_better = TRUE),
+      list(col = "Deveaud2014", label = "Excl. + Coherence", color = "#2ecc71", higher_better = TRUE),
+      list(col = "logLik", label = "Lower Bound", color = "#9b59b6", higher_better = TRUE)
     )
   } else {
     metric_info <- list(
-      list(col = "CaoJuan2009", label = "CaoJuan 2009", color = "#e74c3c", decreasing = TRUE),
-      list(col = "Arun2010", label = "Arun 2010", color = "#3498db", decreasing = FALSE),
-      list(col = "Deveaud2014", label = "Deveaud 2014", color = "#2ecc71", decreasing = TRUE),
-      list(col = "Perplexity", label = "Perplexity", color = "#9b59b6", decreasing = TRUE)
+      list(col = "CaoJuan2009", label = "CaoJuan 2009", color = "#e74c3c", higher_better = FALSE),
+      list(col = "Arun2010", label = "Arun 2010", color = "#3498db", higher_better = FALSE),
+      list(col = "Deveaud2014", label = "Deveaud 2014", color = "#2ecc71", higher_better = TRUE),
+      list(col = "Perplexity", label = "Perplexity", color = "#9b59b6", higher_better = FALSE)
     )
   }
 
@@ -434,15 +447,15 @@ tmMultiMetricPlot <- function(result, method = "LDA") {
   for (m in metric_info) {
     if (!m$col %in% names(df)) next
     vals <- df[[m$col]]
-    # Min-max normalize to [0, 1]; invert if lower = better
-    if (m$decreasing) {
+    # Min-max normalize to [0, 1], so that 1 is always the good end
+    if (m$higher_better) {
       norm_vals <- (vals - min(vals)) / (max(vals) - min(vals) + .Machine$double.eps)
     } else {
       norm_vals <- 1 - (vals - min(vals)) / (max(vals) - min(vals) + .Machine$double.eps)
     }
 
     # Find elbow for this metric
-    k_opt <- find_elbow(df$topics, vals, decreasing = m$decreasing, plot = FALSE)
+    k_opt <- find_elbow(df$topics, vals, decreasing = !m$higher_better, plot = FALSE)
     opt_idx <- which(df$topics == k_opt)
 
     fig <- fig %>%

--- a/inst/tall/tallTopicModel.R
+++ b/inst/tall/tallTopicModel.R
@@ -65,11 +65,19 @@ Deveaud2014 <- function(models) {
 }
 
 # Funzione per valutare un singolo modello
+#
+# NOTE: this and evaluate_tm_parallel()/tmTuning() below have no callers — the
+# Shiny app tunes through tmTuningAsync(). The estimator is kept in step with it
+# anyway so that reviving this path cannot quietly reintroduce VEM tuning of a
+# model that is estimated with Gibbs. Its own defects are NOT repaired here:
+# tmTuning()'s `top_by` default is a length-2 vector that switch() refuses, and
+# Arun2010() calls Matrix::rowSums() on the simple_triplet_matrix that tmTuning()
+# builds. Both are reachable the moment anyone calls it.
 evaluate_single_k <- function(k, dtm, seed = 1234, method = "LDA") {
   if (method == "CTM") {
     model <- CTM(dtm, k = k, control = list(seed = seed))
   } else {
-    model <- LDA(dtm, k = k, method = "VEM", control = list(seed = seed))
+    model <- LDA(dtm, k = k, method = "Gibbs", control = list(iter = 500, seed = seed))
   }
   log_lik <- logLik(model)
   perp <- perplexity(model, newdata = dtm)
@@ -643,74 +651,146 @@ stmBuildMeta <- function(x, group, prevalence) {
 }
 
 # Self-contained LDA/CTM tuning for use inside a future worker.
-# Runs sequentially (no parallel clusters) since it already runs in background.
-# Only depends on package functions: topicmodels, slam, utils, stats.
+# Fits the grid across a PSOCK cluster, falling back to a serial loop if one
+# cannot be created — it already runs in a future worker, where a cluster is
+# possible but not guaranteed.
+# Only depends on package functions: topicmodels, slam, parallel, utils, stats.
 tmTuningAsync <- function(dtm, k_seq, seed, method) {
   # Ensure topicmodels is fully loaded so S4 methods (logLik, perplexity) are registered
   requireNamespace("topicmodels", quietly = TRUE)
   library(topicmodels, quietly = TRUE)
 
-  models_list <- list()
-  metrics_rows <- list()
-
-  for (i in seq_along(k_seq)) {
-    k <- k_seq[i]
-    if (method == "CTM") {
-      model <- topicmodels::CTM(dtm, k = k, control = list(seed = seed))
-    } else {
-      model <- topicmodels::LDA(dtm, k = k, method = "VEM", control = list(seed = seed))
-    }
-    models_list[[paste0("k_", k)]] <- model
-    metrics_rows[[i]] <- data.frame(
-      k = k,
-      logLik = as.numeric(logLik(model)),
-      Perplexity = perplexity(model, newdata = dtm)
-    )
-  }
-
-  metrics <- do.call(rbind, metrics_rows)
-
-  # CaoJuan2009
-  metrics$CaoJuan2009 <- sapply(models_list, function(model) {
-    m1 <- exp(model@beta)
-    pairs <- utils::combn(nrow(m1), 2)
-    cos_dist <- apply(pairs, 2, function(pair) {
-      x <- m1[pair[1], ]; y <- m1[pair[2], ]
-      as.numeric(crossprod(x, y) / sqrt(crossprod(x) * crossprod(y)))
-    })
-    sum(cos_dist) / (model@k * (model@k - 1) / 2)
-  })
-
-  # Arun2010
+  ## Document lengths, needed by Arun2010 and by the workers' own scoring.
+  ## The guard matters: tmTuning() builds a `simple_triplet_matrix`, which
+  ## Matrix::rowSums() cannot take (see the note on evaluate_single_k).
   len <- if (inherits(dtm, "simple_triplet_matrix")) {
     slam::row_sums(dtm)
   } else {
     Matrix::rowSums(dtm)
   }
-  metrics$Arun2010 <- sapply(models_list, function(model) {
-    m1 <- exp(model@beta)
-    m1_svd <- svd(m1)
-    cm1 <- as.matrix(m1_svd$d)
-    m2 <- model@gamma
-    cm2 <- len %*% m2
-    norm_val <- norm(as.matrix(len), type = "m")
-    cm2 <- as.vector(cm2 / norm_val)
+  norm_val <- norm(as.matrix(len), type = "m")
+
+  ## One model per K, fitted AND scored where the model lives.
+  ##
+  ## LDA is fitted with **Gibbs**, as tmEstimate() fits it (`:562`). It used to
+  ## be method = "VEM" here, which meant the K this page recommended came from a
+  ## different model class than the model the user then estimated: two different
+  ## inference algorithms, one choosing the number of topics for the other. CTM
+  ## was never affected — the same CTM() is used on both pages — and STM tunes
+  ## through stm::searchK, which fits stm models. The control list is
+  ## tmEstimate's, iterations included, so the tuned model and the estimated one
+  ## are the same fit.
+  ##
+  ## What comes back is deliberately SMALL: logLik and perplexity are the
+  ## expensive part after the fit itself — they were half the wall clock when
+  ## computed here — and the two pairwise metrics need only `exp(beta)`, while
+  ## Arun2010 needs `len %*% gamma`, a vector of length K. Returning the fitted
+  ## models instead would ship tens of MB per grid back through the socket for
+  ## nothing: `models` was in the return value and NOTHING read it.
+  score_one <- function(k) {
+    model <- if (method == "CTM") {
+      topicmodels::CTM(dtm, k = k, control = list(seed = seed))
+    } else {
+      topicmodels::LDA(dtm, k = k, method = "Gibbs",
+                       control = list(iter = 500, seed = seed))
+    }
+    list(
+      k          = k,
+      logLik     = as.numeric(logLik(model)),
+      Perplexity = perplexity(model, newdata = dtm),
+      beta       = exp(model@beta),
+      cm2        = as.vector(len %*% model@gamma)
+    )
+  }
+
+  ## Fitted across cores. Every fit is independent and carries the SAME seed, so
+  ## the result does not depend on the order they finish in — parallel and
+  ## serial return identical metrics, which is checked rather than assumed.
+  ##
+  ## `parallel::detectCores()` rather than TALL's `coresCPU()`: this function is
+  ## called inside a `promises::future_promise()` worker and is deliberately
+  ## self-contained, and `coresCPU()` both lives in another file and, on
+  ## Windows, creates and registers a cluster as a side effect — one leaked per
+  ## call from here.
+  ##
+  ## Anything that goes wrong with the cluster falls back to scoring serially
+  ## rather than failing the page: a K choice that is slower is still a K
+  ## choice, and this runs inside a future where a cluster is not guaranteed.
+  n_workers <- max(1L, min(length(k_seq),
+                           as.integer(parallel::detectCores(logical = FALSE)) - 1L))
+  scored <- NULL
+  if (length(k_seq) > 1L && n_workers > 1L) {
+    cl <- try(parallel::makeCluster(n_workers), silent = TRUE)
+    if (!inherits(cl, "try-error")) {
+      on.exit(try(parallel::stopCluster(cl), silent = TRUE), add = TRUE)
+      out <- try({
+        parallel::clusterEvalQ(cl, {
+          library(topicmodels)
+          library(slam)
+        })
+        parallel::clusterExport(cl, c("dtm", "seed", "method", "len"),
+                                envir = environment())
+        ## Longest first: the cost of a fit grows with K, and parLapply chunks
+        ## statically, so submitting 2,3,…,20 leaves one worker holding the
+        ## most expensive model while the rest have finished.
+        ord <- order(k_seq, decreasing = TRUE)
+        res <- parallel::parLapply(cl, k_seq[ord], function(k) {
+          model <- if (method == "CTM") {
+            topicmodels::CTM(dtm, k = k, control = list(seed = seed))
+          } else {
+            topicmodels::LDA(dtm, k = k, method = "Gibbs",
+                             control = list(iter = 500, seed = seed))
+          }
+          list(k = k,
+               logLik = as.numeric(logLik(model)),
+               Perplexity = perplexity(model, newdata = dtm),
+               beta = exp(model@beta),
+               cm2 = as.vector(len %*% model@gamma))
+        })
+        res[order(ord)]
+      }, silent = TRUE)
+      if (!inherits(out, "try-error")) scored <- out
+    }
+  }
+  if (is.null(scored)) scored <- lapply(k_seq, score_one)
+
+  metrics <- do.call(rbind, lapply(scored, function(r) {
+    data.frame(k = r$k, logLik = r$logLik, Perplexity = r$Perplexity)
+  }))
+
+  # CaoJuan2009
+  metrics$CaoJuan2009 <- vapply(scored, function(r) {
+    m1 <- r$beta
+    pairs <- utils::combn(nrow(m1), 2)
+    cos_dist <- apply(pairs, 2, function(pair) {
+      x <- m1[pair[1], ]; y <- m1[pair[2], ]
+      as.numeric(crossprod(x, y) / sqrt(crossprod(x) * crossprod(y)))
+    })
+    sum(cos_dist) / (nrow(m1) * (nrow(m1) - 1) / 2)
+  }, numeric(1))
+
+  # Arun2010
+  metrics$Arun2010 <- vapply(scored, function(r) {
+    cm1 <- as.matrix(svd(r$beta)$d)
+    cm2 <- r$cm2 / norm_val
     sum(cm1 * log(cm1 / cm2)) + sum(cm2 * log(cm2 / cm1))
-  })
+  }, numeric(1))
 
   # Deveaud2014
-  metrics$Deveaud2014 <- sapply(models_list, function(model) {
-    m1 <- exp(model@beta)
+  metrics$Deveaud2014 <- vapply(scored, function(r) {
+    m1 <- r$beta
     if (any(m1 == 0)) m1 <- m1 + .Machine$double.xmin
     pairs <- utils::combn(nrow(m1), 2)
     jsd <- apply(pairs, 2, function(pair) {
       x <- m1[pair[1], ]; y <- m1[pair[2], ]
       0.5 * sum(x * log(x / y)) + 0.5 * sum(y * log(y / x))
     })
-    sum(jsd) / (model@k * (model@k - 1))
-  })
+    sum(jsd) / (nrow(m1) * (nrow(m1) - 1))
+  }, numeric(1))
 
-  list(metrics = metrics, models = models_list)
+  ## `models` is gone from the return value: nothing read it, and carrying the
+  ## fitted objects back from the workers was the single largest cost here.
+  list(metrics = metrics)
 }
 
 # Self-contained STM tuning for use inside a future worker.

--- a/inst/tall/tallTopicModel.R
+++ b/inst/tall/tallTopicModel.R
@@ -582,7 +582,20 @@ tmEstimate <- function(
     select(word, all_of(variables))
 
   # for every document we have a probability distribution of its contained topics
-  row_label <- unique(x$doc_id)[as.numeric(row.names(tmResult$topics))]
+  # The row names of `topics` are topic_level_id values -- the ANALYSIS UNIT,
+  # which is a sentence whenever `group` includes sentence_id -- not positions
+  # in unique(doc_id). Indexing the document list with a unit id returned NA for
+  # every unit past the number of documents: on a 6-document corpus split into
+  # 593 sentences, 6 labels resolved and 587 became NA, so Topic by Docs Plot
+  # showed a column of NA. Map each unit back to its own document instead, which
+  # is what stmEstimate() already does a few hundred lines below.
+  unit_map <- x %>%
+    dplyr::distinct(topic_level_id, doc_id) %>%
+    dplyr::arrange(topic_level_id)
+  row_label <- unit_map$doc_id[match(
+    as.numeric(row.names(tmResult$topics)),
+    unit_map$topic_level_id
+  )]
   theta <- tmResult$topics %>%
     as.data.frame() %>%
     mutate(doc = row_label) %>%

--- a/inst/tall/tallTopicModel.R
+++ b/inst/tall/tallTopicModel.R
@@ -837,11 +837,17 @@ stmEstimate <- function(x, dtm, K, group, prevalence = NULL, seed = 1234) {
 
   # Extract theta (document-topic probabilities)
   theta_raw <- topicModel$theta
-  # Get document labels
+  # Get document labels. The rows of theta are the units in `keep_docs` order,
+  # and `keep_docs` carries topic_level_id VALUES, which are neither contiguous
+  # (LemmaSelection drops units, so the ids skip: 3, 4, 5, 7, ...) nor
+  # necessarily the first ones (empty units are dropped above). Taking the first
+  # nrow() rows of the unit list therefore slid the labels: measured on
+  # frankenstein at sentence units, 153 of 593 rows were attributed to the wrong
+  # document. Match each row to its own unit, as tmEstimate() does.
   doc_ids <- x %>%
     distinct(topic_level_id, doc_id) %>%
     arrange(topic_level_id)
-  row_label <- doc_ids$doc_id[seq_len(nrow(theta_raw))]
+  row_label <- doc_ids$doc_id[match(as.numeric(keep_docs), doc_ids$topic_level_id)]
 
   theta <- as.data.frame(theta_raw)
   colnames(theta) <- variables

--- a/inst/tall/tallUtils.R
+++ b/inst/tall/tallUtils.R
@@ -620,12 +620,9 @@ To ensure the functionality of Biblioshiny,
   values$corpus_description <- NULL
   values$gemini_additional <- NULL
 
-  path_gemini_model <- path_gemini_key <- paste0(
-    file.path(home, "tall"),
-    "/.tall_gemini_model.txt",
-    collapse = ""
-  )
-  gemini_api_model <- loadGeminiModel(path_gemini_model)
+  ## one helper, so the writer and the reader cannot drift apart again
+  ## (this also used to clobber `path_gemini_key`, which had just been used)
+  gemini_api_model <- loadGeminiModel(geminiModelFile())
   values$gemini_api_model <- gemini_api_model[1]
   values$gemini_output_size <- gemini_api_model[2]
 

--- a/inst/tall/tallUtils.R
+++ b/inst/tall/tallUtils.R
@@ -493,8 +493,12 @@ wdFolder <- function() {
   wdTall <- NULL
 
   if (file.exists(wdFile)) {
-    wdTall <- readLines(wdFile)
-    if (!file.exists(wdTall)) {
+    wdTall <- readLines(wdFile, warn = FALSE)
+    ## an empty (or blank) file gives character(0) / "", and file.exists() on it
+    ## returns logical(0) — the `if` below then aborts with "argument is of
+    ## length zero", at start-up, before there is a UI to report it in.
+    wdTall <- wdTall[nzchar(trimws(wdTall))][1]
+    if (is.na(wdTall) || !file.exists(wdTall)) {
       file.remove(wdFile)
       wdTall <- NULL
     }
@@ -727,16 +731,22 @@ saveTall <- function(
 deleteCache <- function() {
   home <- homeFolder()
 
-  # setting up the main directory
-  path_tall <- file.path(home, "tall")
+  ## The button is "Clean Model Cache", so clean the model cache.
+  ## It used to unlink(file.path(home, "tall")) — the whole tree, which also
+  ## holds .tall_gemini_key.txt, .tall_graph_settings.txt, tallWD.tall and any
+  ## .tall project the user saved in it. Only the downloaded models are
+  ## re-obtainable, and only they are removed now.
+  path_tall <- file.path(home, "tall", "language_models")
   result <- unlink(path_tall, recursive = TRUE)
+  dir.create(path_tall, showWarnings = FALSE, recursive = TRUE)
   btn_labels <- "OK"
 
   if (result == 0) {
     subtitle <- paste0(
-      "The folder '",
+      "The downloaded language models in '",
       path_tall,
-      "' \nand files contained in it have been correctly deleted"
+      "' \nhave been correctly deleted.",
+      "\nYour settings, working folder and API key have been kept."
     )
     title <- ""
     btn_colors <- "#1d8fe1"

--- a/inst/tall/words.R
+++ b/inst/tall/words.R
@@ -2970,13 +2970,14 @@ wordsServer <- function(input, output, session, values, statsValues) {
       dim = input$w2vDim,
       iter = input$w2vIter
     )
+    ## w2vMatrix() drops word2vec's "</s>" sentinel row, whose untrained vector
+    ## dominated the per-dimension statistics and the PCA of this very tab
+    w2v_emb <- w2vMatrix(values$w2v_model)
     values$w2v_stats <- list()
-    values$w2v_stats$stats <- summary_stats_embeddings(as.matrix(
-      values$w2v_model
-    ))
-    # values$w2v_stats$distances <- distance_similarity_stats(as.matrix(values$w2v_model))
-    values$w2v_stats$pca <- pca_analysis_embeddings(as.matrix(values$w2v_model))
-    values$df_EmbeddingDims <- as.matrix(values$w2v_model) %>%
+    values$w2v_stats$stats <- summary_stats_embeddings(w2v_emb)
+    # values$w2v_stats$distances <- distance_similarity_stats(w2v_emb)
+    values$w2v_stats$pca <- pca_analysis_embeddings(w2v_emb)
+    values$df_EmbeddingDims <- w2v_emb %>%
       as.data.frame() %>%
       tibble::rownames_to_column(var = "Word") %>%
       tidyr::pivot_longer(
@@ -3057,7 +3058,7 @@ wordsServer <- function(input, output, session, values, statsValues) {
       file2 <- destFolder(file2, values$wdTall)
       file3 <- paste("WEpca-", sys.time(), ".png", sep = "")
       file3 <- destFolder(file3, values$wdTall)
-      write.csv(as.matrix(values$w2v_model), file = file1)
+      write.csv(w2vMatrix(values$w2v_model), file = file1)
       plot2png(values$w2vBoxplot, filename = file2, type = "plotly", dpi = values$dpi, height = values$h)
       plot2png(values$w2vPCA, filename = file3, type = "plotly", dpi = values$dpi, height = values$h)
       popUp(title = "Saved in your working folder", type = "saved")

--- a/man/process_multiwords_fast.Rd
+++ b/man/process_multiwords_fast.Rd
@@ -14,7 +14,10 @@ process_multiwords_fast(x2, stats, term = c("lemma", "token"))
 \item{term}{Type of term to process: "lemma" or "token"}
 }
 \value{
-Data frame with columns: doc_id, term_id, multiword, upos_multiword, ngram
+Data frame with columns: doc_id, term_id, multiword, upos_multiword,
+ngram, mw_owner (the keyword that absorbed a NGRAM_MERGED position, NA
+elsewhere — \code{applyRake()} needs it to keep the constituents of the
+selected keywords only)
 }
 \description{
 Complete optimized workflow for multiword detection and processing.

--- a/tests/testthat/test-process_multiwords.R
+++ b/tests/testthat/test-process_multiwords.R
@@ -44,6 +44,55 @@ test_that("process_multiwords_fast returns expected structure", {
   result <- process_multiwords_fast(x2, stats, term = "lemma")
 
   expect_s3_class(result, "data.frame")
-  expect_named(result, c("doc_id", "term_id", "multiword", "upos_multiword", "ngram"))
+  expect_named(result, c("doc_id", "term_id", "multiword", "upos_multiword",
+                         "ngram", "mw_owner"))
   expect_equal(nrow(result), 6)
+})
+
+test_that("process_multiwords_fast tags the absorbed constituents", {
+  x2 <- data.frame(
+    doc_id = rep("doc1", 6),
+    term_id = 1:6,
+    token = c("machine", "learning", "is", "very", "deep", "learning"),
+    lemma = c("machine", "learning", "be", "very", "deep", "learning"),
+    upos = c("NOUN", "NOUN", "AUX", "ADV", "ADJ", "NOUN"),
+    stringsAsFactors = FALSE
+  )
+  stats <- data.frame(keyword = "machine learning", ngram = 2L,
+                      stringsAsFactors = FALSE)
+
+  result <- process_multiwords_fast(x2, stats, term = "lemma")
+
+  # row 1 is the multiword, row 2 is the constituent it absorbed: without the
+  # NGRAM_MERGED tag the word would stay in the corpus twice
+  expect_equal(result$multiword[1], "machine learning")
+  expect_equal(result$upos_multiword[1], "MULTIWORD")
+  expect_equal(result$upos_multiword[2], "NGRAM_MERGED")
+  expect_equal(result$mw_owner[2], "machine learning")
+  expect_true(is.na(result$mw_owner[1]))
+
+  # untouched tokens keep their own tag and have no owner
+  expect_equal(result$upos_multiword[3:6], c("AUX", "ADV", "ADJ", "NOUN"))
+  expect_true(all(is.na(result$mw_owner[3:6])))
+})
+
+test_that("process_multiwords_fast leaves an NA term alone", {
+  # an unresolved lemma is NOT an absorbed constituent: the kernel blanks both,
+  # only the absorbed one may be tagged NGRAM_MERGED
+  x2 <- data.frame(
+    doc_id = rep("doc1", 4),
+    term_id = 1:4,
+    token = c("machine", "learning", "x", "cool"),
+    lemma = c("machine", "learning", NA_character_, "cool"),
+    upos = c("NOUN", "NOUN", "X", "ADJ"),
+    stringsAsFactors = FALSE
+  )
+  stats <- data.frame(keyword = "machine learning", ngram = 2L,
+                      stringsAsFactors = FALSE)
+
+  result <- process_multiwords_fast(x2, stats, term = "lemma")
+
+  expect_equal(result$upos_multiword[2], "NGRAM_MERGED")
+  expect_true(is.na(result$upos_multiword[3]))   # NA term -> untouched
+  expect_true(is.na(result$mw_owner[3]))
 })


### PR DESCRIPTION
Everything on `develop` since the last merge to `master`: **16 commits, 32 NEWS entries**, across nine menus. The branch has grown well past what this description originally covered (four fixes, 2026-07-30), so it is rewritten here in full.

Every fix was verified by **executing** the affected function against a real corpus — not by reading it — and each carries a NEWS.md entry. Where a fix changes numbers a user has already seen, that is called out explicitly below.

---

## Settings › Tall AI

**A valid Gemini API key was reported as refused, and a new user could not run Tall AI at all** (`a2c5097`). Key validation sent a real `generateContent` request to a hard-coded `gemini-2.5-flash`, and Google has stopped serving the 2.5 family to newly created API keys — so the probe returned `404 … no longer available to new users` and the app said "API key seems be not valid", whatever model was selected. The first-run default was `2.5-flash` too, so even a key that got through had nothing it could call. Same defect as bibliometrix #637, found by carrying that fix across.

- **Validation is now model-agnostic**: `.geminiAvailableModels()` asks for the model **catalogue** (`GET /v1beta/models`) instead of invoking a model, so no future retirement can break it. `geminiValidateKey()` answers about the key and about the chosen model as two separate things.
- **The selected model is checked** against that catalogue, so a wrong choice is reported in Settings instead of surfacing as an HTTP 404 at the first analysis.
- **Errors are told apart.** `grepl("HTTP\s*[1-5][0-9]{2}")` collapsed every status from 100 to 599 into one "invalid key" message. Now 400/401 name the key, 403 a permission, 404 the model, and a transport failure says it is a connection problem.
- **Google's own message finally arrives.** `resp_body_string()` was being handed a hand-built list rather than a response, so the fallback text was always shown. Live check with an invalid key: before, `HTTP 400: Please check your API key. It seems to be not valid!`; after, `HTTP 400: API key not valid. Please pass a valid API key.`
- **A network failure no longer crashes the check.** The connection-level branch in `gemini_ai()` was commented out, leaving `status_code = NA`, so `if (resp$status_code == 400)` evaluated `if (NA)`. Before, the user saw the R error *"missing value where TRUE/FALSE needed"*; after, "This is a connection problem, not your API key."
- **Defaults moved to `gemini-3.5-flash-lite`** (transport, first run, selector). A stored `2.5-flash` was the old default rather than anyone's choice, so it is carried forward; a deliberately chosen `2.5-flash-lite` is kept. The 2.5 pair stays selectable under a **Legacy** group — keys created before the cut-off still reach it. The two **preview** ids are dropped (they carry their own expiry date) and `gemini-flash-latest` added.
- `setGeminiAPI()` removed: unreachable, and a duplicate of the same faulty probe.

**The chosen model and output size never survived a restart** (`b8ed88e`). The choice was written to `~/.tall_gemini_model.txt` and read from `~/tall/.tall_gemini_model.txt`, so Tall AI always came back on its default. Also fixed the writer, which referenced a non-existent input and dropped the output size, and `length(model == 1)` — `length()` of a *logical* vector, so the branch always ran and appended a third element to a complete pair.

**Two defects in the Settings menu** (`bb81c55`): "Clean Model Cache" removed the whole download folder rather than the models, and an empty or blank `~/tall/tallWD.tall` aborted start-up.

## Documents › Topic Modeling

**Find optimal K tuned a different algorithm from the one that estimates the model** (`b100fc9`, `000ee4b`). `tmTuningAsync()` fitted `LDA(dtm, k, method = "VEM")` while `tmEstimate()` fits `method = "Gibbs"` with `iter = 500` — so the K a user was shown had been chosen for a model class they never fitted. Tuning now uses Gibbs with `tmEstimate()`'s own control list. ⚠ **The recommended K will change on existing corpora** — that is the point of the fix.

Also on that page: the **metric direction was wrong on the charts** (CaoJuan and Arun are minimised, Deveaud maximised, and the plots did not say so), the grid is now fitted **across cores** via `parLapply`, one inert flag is documented as inert, and the Deveaud description was corrected.

**Model Estimation: the theta document labels were wrong** (`5c59d0e`, `ee76493`) — in LDA/CTM and again in STM. The per-document topic table attributed rows to the wrong documents.

## Import › Wikipedia

**Nothing on this path was URL-encoded** (`533b029`), so any page whose title contained a space or a non-ASCII character failed to import.

## Documents › Summarization › Extractive

**Two defects** (`ce0383d`): `textrankDocument()` joined sentences in a way that corrupted the output, and the view failed outright on a grouped corpus.

## Words › Word Embeddings

**Four defects** (`0e2b7f1`): the community-detection step in Similarity, the empty-graph case when no pair of words reached the threshold, UMAP with a single word to place, and the `</s>` sentence-boundary row that `word2vec` keeps in its matrix and that was being treated as a term.

## Documents › Supervised Classification

**Six defects** (`324ec5c`): Download Results, `ranger`'s probability handling, a training-set accuracy computed against the wrong reference, training word embeddings from the wrong frame, a failed run leaving stale state behind, and the prerequisite check.

## Features › Feature Roles

**Six defects** (`4945225`): a keyness role on a **binary** variable, time and label roles assigned to the wrong column, the category list of the keyness variable, the "Documents per period" preview table, date-time aggregation **by Day**, and `noGroupLabels()` not reserving `time_agg`.

## Pre-processing › Multi-Word

**Merging a multi-word left its constituents in the corpus** (`84e9691`). After merging "natural philosophy", `philosophy` survived as its own selected NOUN, so vocabulary, keyness, networks and topic models all counted the words twice. Two chained causes: a nested `ifelse()` whose outer test evaluated to `NA` on an absorbed position, making the `NGRAM_MERGED` branch unreachable; and `applyRake()` matching on a column that is `NA` on exactly those rows by construction. Constituents are now tagged `NGRAM_MERGED` with `POSSelected = FALSE` — their text stays in the sentence, they are only excluded from the analyses — and "Back" restores the previous selection. Verified on Frankenstein: 22 merges now produce 22 tagged constituents, previously 0, with the merged heads and their offsets unchanged.

## Elsewhere (`a0b029c`)

- **Reinert clustering**: in the greedy reallocation step, the document to move was looked up in the original `order_docs` indices instead of the current group order, so after the first move it could switch the wrong document — and it made results depend on the arbitrary SVD sign.
- **Overview › Morphological Features**: `parseMorphFeatures()` built its match mask from the *compacted* `regmatches()` vector. Being all-`TRUE` and shorter than the input, the mask was recycled, so extracted values were sprayed cyclically across every token and nothing was dropped as `NA` — the bar chart reported counts inflated to the whole corpus token count.
- **KWIC › In-Document Plot › View**: clicking View on a document with an unresolved lemma aborted the modal with "missing value where TRUE/FALSE needed".

## Documentation and repository

- `f43d57c` — the man page for `process_multiwords_fast()` regenerated: the roxygen block had documented the `mw_owner` column since it was added, but `man/` had never been rebuilt. Documentation only.
- `dfa417d` — the OpenAlex research files and `tasks/` excluded from git and from the build.

---

## Checks

`R CMD INSTALL` clean; all 43 R files parse; the testthat suite green against the patched install (`calculate_ngram_is` 12, `process_multiwords` 21, `reinert` 15, `txt_recode_fast` 6).

The Gemini work was verified against a local stub (13 checks: catalogue, embed-only models excluded, a missing model reported rather than refused, 403 vs 404 vs dead connection, the first-run default, the migration off `2.5-flash`, a deliberate Legacy choice kept) and against the live endpoint with an invalid key for the two before/after comparisons quoted above. No credentials were used and no quota spent.

Note for review: this branch has never been through CI — the repository has no workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
